### PR TITLE
[FEATURE] Allow custom mapping from OIDC to TYPO3

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -21,3 +21,18 @@ OidcAuth {
         }
     }
 }
+
+# format is "TYPO3 column" = <OIDC field>
+plugin.tx_oidc.mapping {
+    fe_users {
+        username   = <contact_number>
+        name       = <name>
+        first_name = <given_name>
+        last_name  = <family_name>
+        address    = <street_address>
+        title      = <title>
+        zip        = <postal_code>
+        city       = <locality>
+        country    = <country>
+    }
+}


### PR DESCRIPTION
Default mapping is configured as follows (TYPO3 column = <OIDC field>):

plugin.tx_oidc.mapping {
    fe_users {
        username   = <contact_number>
        name       = <name>
        first_name = <given_name>
        last_name  = <family_name>
        address    = <street_address>
        title      = <title>
        zip        = <postal_code>
        city       = <locality>
        country    = <country>
    }
}

It is possible to use multiple OIDC fields or constants in the mapping:

username = user_<contact_number>
name = <family_name>, <given_name>

It is possible to apply stdWrap to a field:

username = <contact_number>
username.wrap = user_|

Resolves: #14