### PR TITLE
[FEATURE] Allow to add frontend language to authorize request

### DIFF
--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -51,11 +51,21 @@ class OAuthService
     /**
      * Returns the authorization URL.
      *
+     * @param array $options
      * @return string
      */
-    public function getAuthorizationUrl()
+    public function getAuthorizationUrl(array $options = [])
     {
-        $authorizationUrl = $this->getProvider()->getAuthorizationUrl();
+        if (! empty($this->settings['oidcAuthorizeLanguageParameter'])) {
+            $languageOption = $this->settings['oidcAuthorizeLanguageParameter'];
+
+            if (isset($GLOBALS['TSFE']->lang)) {
+                $frontendLanguage = $GLOBALS['TSFE']->lang;
+                $options[$languageOption] = $frontendLanguage;
+            }
+        }
+
+        $authorizationUrl = $this->getProvider()->getAuthorizationUrl($options);
 
         return $authorizationUrl;
     }

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -21,6 +21,9 @@
 			<trans-unit id="settings.oidcClientScopes">
 				<source>Client Scopes:</source>
 			</trans-unit>">
+			<trans-unit id="settings.oidcAuthorizeLanguageParameter">
+				<source>Authorize request language parameter name</source>
+			</trans-unit>
 			<trans-unit id="settings.oidcEndpointAuthorize">
 				<source>Endpoint URI for authorization</source>
 			</trans-unit>
@@ -45,6 +48,7 @@
 			<trans-unit id="fe_groups.tx_oidc_pattern">
 				<source>Case-insensitive pattern to match OpenID Connect role names ("*" matches every character, "|" to separate expressions)</source>
 			</trans-unit>
+
 		</body>
 	</file>
 </xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -37,6 +37,9 @@ oidcEndpointLogout = https://ids02.sac-cas.ch/oauth2/logout
 # cat=advanced/links/5; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcEndpointRevoke
 oidcEndpointRevoke = https://ids02.sac-cas.ch/oauth2/revoke
 
+# cat=advanced/links/6; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcAuthorizeLanguageParameter
+oidcAuthorizeLanguageParameter = language
+
 # cat=advanced/enable/1; type=boolean; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcUseRequestPathAuthentication
 oidcUseRequestPathAuthentication = 0
 


### PR DESCRIPTION
Introduce a new configuration parameter oidcAuthorizeLanguageParameter.
This allows to pass the current frontend language to the authorization
server as part of the authorization request.