### PR TITLE
Fixes #47: static use of SaltFactory

### DIFF
--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -285,8 +285,7 @@ class AuthenticationService extends \TYPO3\CMS\Sv\AuthenticationService
             ? (new \TYPO3\CMS\Core\Information\Typo3Version())->getBranch()
             : TYPO3_branch;
         if (version_compare($typo3Branch, '9.0', '>=')) {
-            $saltFactory = GeneralUtility::makeInstance(\TYPO3\CMS\Saltedpasswords\Salt\SaltFactory::class);
-            $objInstanceSaltedPW = $saltFactory->getDefaultHashInstance(TYPO3_MODE);
+            $objInstanceSaltedPW = \TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory::getDefaultHashInstance(TYPO3_MODE);
         } else {
             $objInstanceSaltedPW = \TYPO3\CMS\Saltedpasswords\Salt\SaltFactory::getSaltingInstance(null, TYPO3_MODE);
         }

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -285,7 +285,8 @@ class AuthenticationService extends \TYPO3\CMS\Sv\AuthenticationService
             ? (new \TYPO3\CMS\Core\Information\Typo3Version())->getBranch()
             : TYPO3_branch;
         if (version_compare($typo3Branch, '9.0', '>=')) {
-            $objInstanceSaltedPW = \TYPO3\CMS\Saltedpasswords\Salt\SaltFactory::getDefaultHashInstance(TYPO3_MODE);
+            $saltFactory = GeneralUtility::makeInstance(\TYPO3\CMS\Saltedpasswords\Salt\SaltFactory::class);
+            $objInstanceSaltedPW = $saltFactory->getDefaultHashInstance(TYPO3_MODE);
         } else {
             $objInstanceSaltedPW = \TYPO3\CMS\Saltedpasswords\Salt\SaltFactory::getSaltingInstance(null, TYPO3_MODE);
         }


### PR DESCRIPTION
v1.0.0 of the extension uses `SaltFactory::getDefaultHashInstance(TYPO3_MODE)` instead of the `GeneralUtility::makeInstance(SaltFactory::class)->getDefaultHashInstance(TYPO3_MODE)` suggested in the [developers guide](https://docs.typo3.org/c/typo3/cms-saltedpasswords/master/en-us/DevelopersGuide/Index.html). 

This causes errors like this:
```
Core: Error handler (FE): PHP Runtime Deprecation Notice: Non-static method TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory::getDefaultHashInstance() should not be called statically in [...]/typo3conf/ext/oidc/Classes/Service/AuthenticationService.php line 288
```

This PR fixes this error & #47.