### PR TITLE
[TASK] Make extension compatible with TYPO3 v10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "php": ">= 7.0.0, <= 7.4.99",
-    "typo3/cms-core": "^8.7 || ^9.5",
+    "typo3/cms-core": "^8.7 || ^9.5 || ^10.4",
     "league/oauth2-client": "^2.0"
   },
   "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -22,7 +22,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'php' => '7.0.0-7.4.99',
-            'typo3' => '8.7.0-9.5.99',
+            'typo3' => '8.7.0-10.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,6 +2,11 @@
 defined('TYPO3_MODE') || die();
 
 $boot = function ($_EXTKEY) {
+    if (class_exists(\TYPO3\CMS\Core\Authentication\AuthenticationService::class)
+        && !class_exists(\TYPO3\CMS\Sv\AuthenticationService::class)) {
+        class_alias(\TYPO3\CMS\Core\Authentication\AuthenticationService::class, \TYPO3\CMS\Sv\AuthenticationService::class);
+    }
+
     // Configuration of authentication service
     $typo3Branch = class_exists(\TYPO3\CMS\Core\Information\Typo3Version::class)
         ? (new \TYPO3\CMS\Core\Information\Typo3Version())->getBranch()


### PR DESCRIPTION
Once the compatibility with CMS < 10 is lifted, the class alias can be removed.