### PR TITLE
Fix callback redirect for nginx catchall host name

### DIFF
--- a/Resources/Public/callback.php
+++ b/Resources/Public/callback.php
@@ -15,9 +15,15 @@
 // see https://github.com/thephpleague/oauth2-client
 if (!(empty($_GET['state']) || empty($_GET['code']))) {
     $schema = (@$_SERVER['HTTPS'] === 'on') ? 'https://' : 'http://';
-    $currentUrl = $schema . $_SERVER['SERVER_NAME'];
-    if ($_SERVER['SERVER_PORT'] !== '80' && $_SERVER['SERVER_PORT'] !== '443') {
-        $currentUrl .= ':' . $_SERVER['SERVER_PORT'];
+    if ($_SERVER['SERVER_NAME'] !== '_') {
+        $currentUrl = $schema . $_SERVER['SERVER_NAME'];
+        if ($_SERVER['SERVER_PORT'] !== '80' && $_SERVER['SERVER_PORT'] !== '443') {
+            $currentUrl .= ':' . $_SERVER['SERVER_PORT'];
+        }
+    } else {
+        //nginx catchall server name.
+        // Rely on HTTP Host header, which contains non-standard ports as well
+        $currentUrl = $schema . $_SERVER['HTTP_HOST'];
     }
     $currentUrl .= $_SERVER['REQUEST_URI'];
 


### PR DESCRIPTION
When nginx is running in a docker container, the server_name is often "_" [1]:
> In catch-all server examples the strange name “_” can be seen:
> server {
>     listen       80  default_server;
>     server_name  _;
>     return       444;
> }
> There is nothing special about this name, it is just one of a myriad
> of invalid domain names which never intersect with any real name.

Since callback.php uses $\_SERVER['SERVER_NAME'] and thus redirects to
http://\_/?type=1489657462&state=...

This patch detects that special host name and falls back to using
the HTTP "Host" header instead.

When a non-standard port is used, the Host header also contains
the port number[2], so no further port detection is needed.

[1] https://nginx.org/en/docs/http/server_names.html
[2] https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23