### PR TITLE
[FEATURE] Extend user storage

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,7 +13,7 @@ frontendUserMustExistLocally = 0
 # cat=basic/enable/5; type=boolean; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.enableCodeVerifier
 enableCodeVerifier = 0
 
-# cat=basic//1; type=int; label=Storage Pid: The Storage Pid of the Page, where the fe_users should be stored
+# cat=basic//1; type=string; label=Storage Pid: Coma separated list of uid's from pages where fe_users are located. The first uid is used to store new users.
 usersStoragePid =
 
 # cat=basic//2; type=string; label=Default user group(s) (comma-separated list of UIDs)


### PR DESCRIPTION
As userStoragePid a coma-separated list can now be provided.
The first item is used to store new users.

Resolves: #79