### PR TITLE
Compatibility v11

### DIFF
--- a/Classes/Event/AuthenticationGetUserEvent.php
+++ b/Classes/Event/AuthenticationGetUserEvent.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\Oidc\Event;
+
+final class AuthenticationGetUserEvent
+{
+    /**
+     * @var array|bool
+     */
+    protected $user;
+
+    /**
+     * @param array|bool $user
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Array with user if authentication was successfull or false on failure.
+     * @return array|bool
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param array|bool $user
+     */
+    public function setUser($user): void
+    {
+        $this->user = $user;
+    }
+}

--- a/Classes/Factory/GenericOAuthProviderFactory.php
+++ b/Classes/Factory/GenericOAuthProviderFactory.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\Oidc\Factory;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class GenericOAuthProviderFactory implements OAuthProviderFactoryInterface
+{
+
+    public function create(array $settings): AbstractProvider
+    {
+        return new \League\OAuth2\Client\Provider\GenericProvider([
+                'clientId' => $settings['oidcClientKey'],
+                'clientSecret' => $settings['oidcClientSecret'],
+                'redirectUri' => $settings['oidcRedirectUri'],
+                'urlAuthorize' => $settings['oidcEndpointAuthorize'],
+                'urlAccessToken' => $settings['oidcEndpointToken'],
+                'urlResourceOwnerDetails' => $settings['oidcEndpointUserInfo'],
+                'scopes' => GeneralUtility::trimExplode(',', $settings['oidcClientScopes'], true),
+            ]);
+    }
+}

--- a/Classes/Factory/OAuthProviderFactoryInterface.php
+++ b/Classes/Factory/OAuthProviderFactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\Oidc\Factory;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+
+interface OAuthProviderFactoryInterface
+{
+    public function create(array $settings): AbstractProvider;
+}

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -14,7 +14,9 @@
 
 namespace Causal\Oidc\Service;
 
+use Causal\Oidc\Event\AuthenticationGetUserEvent;
 use League\OAuth2\Client\Token\AccessToken;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
@@ -123,6 +125,18 @@ class AuthenticationService extends \TYPO3\CMS\Sv\AuthenticationService
         // provided by the authentication server
         $dispatcher = GeneralUtility::makeInstance(ObjectManager::class)->get(Dispatcher::class);
         $dispatcher->dispatch(__CLASS__, 'getUser', ['user' => $user]);
+
+        $typo3Branch = class_exists(\TYPO3\CMS\Core\Information\Typo3Version::class)
+            ? (new \TYPO3\CMS\Core\Information\Typo3Version())->getBranch()
+            : TYPO3_branch;
+
+        if (version_compare($typo3Branch, '10.2', '>=')) {
+            $event = new AuthenticationGetUserEvent($user);
+            $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+            $eventDispatcher->dispatch($event);
+            $user = $event->getUser();
+        }
+
         if (is_array($user)) {
             unset($user['accessToken']);
         }

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -29,6 +29,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Core\Context\Context;
 
 /**
  * OpenID Connect authentication service.
@@ -697,7 +698,8 @@ class AuthenticationService extends \TYPO3\CMS\Sv\AuthenticationService
             $currentPage = $pageArguments->getPageId();
 
             $frontendUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
-            $localTSFE = GeneralUtility::makeInstance(TypoScriptFrontendController::class, null, $site, $routeResult->getLanguage(), $pageArguments, $frontendUser);
+            $context = GeneralUtility::makeInstance(Context::class);
+            $localTSFE = GeneralUtility::makeInstance(TypoScriptFrontendController::class, $context, $site, $routeResult->getLanguage(), $pageArguments, $frontendUser);
 
             /** @var TemplateService $templateService */
             $templateService = GeneralUtility::makeInstance(TemplateService::class, null, null, $localTSFE);

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -67,6 +67,9 @@
 			<trans-unit id="fe_users.tx_oidc">
 				<source>OpenID Connect Identifier</source>
 			</trans-unit>
+			<trans-unit id="settings.oauthProviderFactory">
+				<source>OAuth Provider Factory: Fully qulified class name (empty for generic provider).</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "php": ">= 7.0.0, <= 7.4.99",
-    "typo3/cms-core": "^8.7 || ^9.5 || ^10.4",
+    "typo3/cms-core": "^8.7 || ^9.5 || ^10.4 || ^11.5",
     "league/oauth2-client": "^2.0"
   },
   "autoload": {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -57,3 +57,6 @@ oidcRevokeAccessTokenAfterLogin = 0
 
 # cat=advanced/enable/2; type=boolean; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcDisableCSRFProtection
 oidcDisableCSRFProtection = 0
+
+# cat=advanced//3; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oauthProviderFactory
+oauthProviderFactory =

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,11 +11,11 @@ $EM_CONF[$_EXTKEY] = [
     'createDirs' => '',
     'modify_tables' => '',
     'clearCacheOnLoad' => 0,
-    'version' => '1.1.0',
+    'version' => '1.2.0-dev',
     'constraints' => [
         'depends' => [
             'php' => '7.0.0-7.4.99',
-            'typo3' => '8.7.0-10.4.99',
+            'typo3' => '8.7.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -48,17 +48,31 @@ defined('TYPO3_MODE') || die();
         ]
     );
 
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Causal.' . $_EXTKEY,
-        'Pi1',
-        [
-            'Authentication' => 'connect',
-        ],
-        // non-cacheable actions
-        [
-            'Authentication' => 'connect'
-        ]
-    );
+    if (version_compare($typo3Branch, '10.0', '<')) {
+        \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+            'Causal.' . $_EXTKEY,
+            'Pi1',
+            [
+                'Authentication' => 'connect',
+            ],
+            // non-cacheable actions
+            [
+                'Authentication' => 'connect'
+            ]
+        );
+    } else {
+        \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+            $_EXTKEY,
+            'Pi1',
+            [
+                \Causal\Oidc\Controller\AuthenticationController::class => 'connect',
+            ],
+            // non-cacheable actions
+            [
+                \Causal\Oidc\Controller\AuthenticationController::class => 'connect'
+            ]
+        );
+    }
 
     if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('felogin')) {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['felogin']['postProcContent'][$_EXTKEY] = \Causal\Oidc\Hooks\FeloginHook::class . '->postProcContent';


### PR DESCRIPTION
This pull request
- adds compatibility with TYPO3 v11
- makes oauth provider configurable
- adds an event for the getUser signal as a replacement in future versions

Resolves #78 and #81