### PR TITLE
Add support for ports at the login url

### DIFF
--- a/Classes/Hooks/FeloginHook.php
+++ b/Classes/Hooks/FeloginHook.php
@@ -102,6 +102,7 @@ class FeloginHook
         ]);
 
         $loginUrl = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
+
         // Sanitize the URL
         $parts = parse_url($loginUrl);
         $queryParts = array_filter(explode('&', $parts['query']), function ($v) {
@@ -110,7 +111,7 @@ class FeloginHook
             return !in_array($k, ['logintype', 'tx_oidc[code]']);
         });
         $parts['query'] = implode('&', $queryParts);
-        $loginUrl = $parts['scheme'] . '://' . $parts['host'] . $parts['path'];
+        $loginUrl = $parts['scheme'] . '://' . $parts['host'] .(!empty($parts["port"]) && $parts["port"] != 80 && $parts["port"] != 443 ? ":".$parts["port"] : ""). $parts['path'];
         if (!empty($parts['query'])) {
             $loginUrl .= '?' . $parts['query'];
         }

--- a/Classes/ViewHelpers/OidcLinkViewHelper.php
+++ b/Classes/ViewHelpers/OidcLinkViewHelper.php
@@ -103,6 +103,7 @@ class OidcLinkViewHelper extends AbstractViewHelper
         ]);
 
         $loginUrl = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
+
         // Sanitize the URL
         $parts = parse_url($loginUrl);
         $queryParts = array_filter(explode('&', $parts['query']), function ($v) {
@@ -111,7 +112,7 @@ class OidcLinkViewHelper extends AbstractViewHelper
             return !in_array($k, ['logintype', 'tx_oidc[code]']);
         });
         $parts['query'] = implode('&', $queryParts);
-        $loginUrl = $parts['scheme'] . '://' . $parts['host'] . $parts['path'];
+        $loginUrl = $parts['scheme'] . '://' . $parts['host'] .(!empty($parts["port"]) && $parts["port"] != 80 && $parts["port"] != 443 ? $parts["port"] : ""). $parts['path'];
         if (!empty($parts['query'])) {
             $loginUrl .= '?' . $parts['query'];
         }

--- a/Classes/ViewHelpers/OidcLinkViewHelper.php
+++ b/Classes/ViewHelpers/OidcLinkViewHelper.php
@@ -112,7 +112,7 @@ class OidcLinkViewHelper extends AbstractViewHelper
             return !in_array($k, ['logintype', 'tx_oidc[code]']);
         });
         $parts['query'] = implode('&', $queryParts);
-        $loginUrl = $parts['scheme'] . '://' . $parts['host'] .(!empty($parts["port"]) && $parts["port"] != 80 && $parts["port"] != 443 ? $parts["port"] : ""). $parts['path'];
+        $loginUrl = $parts['scheme'] . '://' . $parts['host'] .(!empty($parts["port"]) && $parts["port"] != 80 && $parts["port"] != 443 ? ":".$parts["port"] : ""). $parts['path'];
         if (!empty($parts['query'])) {
             $loginUrl .= '?' . $parts['query'];
         }


### PR DESCRIPTION
The code currently didn't support ports at the login url. 
I use docker and my login url is something like: http://localhost:2513/login
After redirect from the openid connect service (A keycloak service), the port is missing at the url. 
I love your work. Please merge my pull request that I can use your code in future. 
Its tested with Port 80, 443 and a random Port (2513) and should work for all typo3 versions.
