### PR TITLE
Add a custom user groups event

### DIFF
--- a/Classes/Event/AuthenticationGetUserGroupsEvent.php
+++ b/Classes/Event/AuthenticationGetUserGroupsEvent.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Causal\Oidc\Event;
+
+/**
+ * Customize user group mapping
+ * if your resource owner structure differs form the default "Roles" workflow
+ */
+final class AuthenticationGetUserGroupsEvent
+{
+	/**
+	 * @var array
+	 */
+	protected $groupTable;
+	/**
+	 * @var array
+	 */
+	protected $groups;
+	/**
+	 * @var array
+	 */
+	protected $resource;
+
+	/**
+	 * @param string $groupTable - fe_groups or be_groups
+	 * @param array $groups - known user group ids
+	 * @param array $resourceOwner - resource owner data
+	 */
+	public function __construct($groupTable, $groups, $resourceOwner)
+	{
+		$this->groupTable = (string)$groupTable;
+		$this->groups = $groups;
+		$this->resource = $resourceOwner;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getGroupTable()
+	{
+		return $this->groupTable;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getUserGroups()
+	{
+		return $this->groups;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getResource()
+	{
+		return $this->resource;
+	}
+
+	/**
+	 * Set your customized user group ids
+	 * @param array $groups
+	 */
+	public function setUserGroups($groups): void
+	{
+		$this->groups = $groups;
+	}
+}


### PR DESCRIPTION
* to map the groups by a a different pattern if "Roles" does not fit
* for example work with "claims" or "group_membership" data in a custom listener