### PR TITLE
Add event to manipulate login data before processing

### DIFF
--- a/Classes/Event/AuthenticationPreUserEvent.php
+++ b/Classes/Event/AuthenticationPreUserEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\Oidc\Event;
+
+final class AuthenticationPreUserEvent
+{
+    public array $loginData = [];
+    public bool $shouldProcess = true;
+
+    public function __construct(array $loginData)
+    {
+        $this->loginData = $loginData;
+    }
+}

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -109,7 +109,8 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
     public function getUser()
     {
         $user = false;
-        $params = GeneralUtility::_GET('tx_oidc');
+        $request = ServerRequestFactory::fromGlobals();
+        $params = $request->getQueryParams()['tx_oidc'] ?? [];
         $code = $params['code'] ?? null;
         $username = $this->login['uname'] ?? null;
 

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -20,8 +20,6 @@ namespace Causal\Oidc\Service;
 use Causal\Oidc\Event\AuthenticationGetUserEvent;
 use Causal\Oidc\Event\ModifyResourceOwnerEvent;
 use Causal\Oidc\Event\ModifyUserEvent;
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Driver\Exception;
 use InvalidArgumentException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Causal\Oidc\Service;
 
 use Causal\Oidc\Event\AuthenticationGetUserEvent;
+use Causal\Oidc\Event\AuthenticationPreUserEvent;
 use Causal\Oidc\Event\ModifyResourceOwnerEvent;
 use Causal\Oidc\Event\ModifyUserEvent;
 use InvalidArgumentException;
@@ -108,28 +109,37 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
      */
     public function getUser()
     {
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+
         $user = false;
         $request = ServerRequestFactory::fromGlobals();
         $params = $request->getQueryParams()['tx_oidc'] ?? [];
         $code = $params['code'] ?? null;
-        $username = $this->login['uname'] ?? null;
-
-        if (isset($this->login['uident_text'])) {
-            $password = $this->login['uident_text'];
-        } elseif (isset($this->login['uident'])) {
-            $password = $this->login['uident'];
-        } else {
-            $password = null;
-        }
-
         if ($code !== null) {
             $codeVerifier = null;
             if ($this->config['enableCodeVerifier']) {
                 $codeVerifier = $this->getCodeVerifierFromSession();
             }
             $user = $this->authenticateWithAuthorizationCode($code, $codeVerifier);
-        } elseif (!(empty($username) || empty($password))) {
-            $user = $this->authenticateWithResourceOwnerPasswordCredentials($username, $password);
+        } else {
+            $event = new AuthenticationPreUserEvent($this->login);
+            $eventDispatcher->dispatch($event);
+            if (!$event->shouldProcess) {
+                return false;
+            }
+            $this->login = $event->loginData;
+
+            $username = $this->login['uname'] ?? null;
+            if (isset($this->login['uident_text'])) {
+                $password = $this->login['uident_text'];
+            } elseif (isset($this->login['uident'])) {
+                $password = $this->login['uident'];
+            } else {
+                $password = null;
+            }
+            if (!empty($username) && !empty($password)) {
+                $user = $this->authenticateWithResourceOwnerPasswordCredentials($username, $password);
+            }
         }
 
         // dispatch a signal (containing the user with his access token if auth was successful)
@@ -140,7 +150,6 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
         $dispatcher->dispatch(__CLASS__, 'getUser', ['user' => $user]);
 
         $event = new AuthenticationGetUserEvent($user);
-        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
         $eventDispatcher->dispatch($event);
         $user = $event->getUser();
 


### PR DESCRIPTION
This is useful if one needs to filter whether certain logins should be processed at all.

Example: Only process logins, where the username matches certain criteria.