### PR TITLE
Replace PHP session with JWT

### DIFF
--- a/Classes/AuthenticationContext.php
+++ b/Classes/AuthenticationContext.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Causal\Oidc;
+
+use Causal\Oidc\Security\JwtTrait;
+
+class AuthenticationContext
+{
+    use JwtTrait;
+
+    public string $requestId = '';
+    public string $state = '';
+    public string $loginUrl = '';
+    public string $authorizationUrl = '';
+    public string $redirectUrl = '';
+    public ?string $codeVerifier = null;
+
+    public function __construct(
+        string $state,
+        string $loginUrl,
+        string $authorizationUrl,
+        string $requestId = '',
+        string $redirectUrl = '',
+        ?string $codeVerifier = null
+    ) {
+        $this->state = $state;
+        $this->loginUrl = $loginUrl;
+        $this->authorizationUrl = $authorizationUrl;
+        $this->requestId = $requestId;
+        $this->redirectUrl = $redirectUrl;
+        $this->codeVerifier = $codeVerifier;
+    }
+
+    public static function fromJwt(string $cookieValue): self
+    {
+        $payload = self::decodeJwt($cookieValue, self::createSigningKeyFromEncryptionKey(static::class), true);
+        return new self(...$payload);
+    }
+
+    public function toHashSignedJwt(): string
+    {
+        $payload = get_object_vars($this);
+        return self::encodeHashSignedJwt($payload, self::createSigningKeyFromEncryptionKey(static::class));
+    }
+}

--- a/Classes/AuthenticationContext.php
+++ b/Classes/AuthenticationContext.php
@@ -10,18 +10,18 @@ class AuthenticationContext
 {
     use JwtTrait;
 
-    public string $requestId = '';
-    public string $state = '';
-    public string $loginUrl = '';
-    public string $authorizationUrl = '';
-    public string $redirectUrl = '';
-    public ?string $codeVerifier = null;
+    protected string $requestId;
+    protected string $state;
+    protected string $loginUrl;
+    protected string $authorizationUrl;
+    public string $redirectUrl;
+    public ?string $codeVerifier;
 
     public function __construct(
         string $state,
         string $loginUrl,
         string $authorizationUrl,
-        string $requestId = '',
+        string $requestId,
         string $redirectUrl = '',
         ?string $codeVerifier = null
     ) {
@@ -31,6 +31,26 @@ class AuthenticationContext
         $this->requestId = $requestId;
         $this->redirectUrl = $redirectUrl;
         $this->codeVerifier = $codeVerifier;
+    }
+
+    public function getAuthorizationUrl(): string
+    {
+        return $this->authorizationUrl;
+    }
+
+    public function getLoginUrl(): string
+    {
+        return $this->loginUrl;
+    }
+
+    public function getState(): string
+    {
+        return $this->state;
+    }
+
+    public function getRequestId(): string
+    {
+        return $this->requestId;
     }
 
     public static function fromJwt(string $cookieValue): self

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -79,12 +79,12 @@ class LoginController
     protected function determineAuthorizationUrl(array $authorizationUrlOptions): string
     {
         $oidcService = GeneralUtility::makeInstance(OpenIdConnectService::class);
-        $authorizationUrl = $oidcService->generateOpenidConnectUri($authorizationUrlOptions);
+        $authContext = $oidcService->generateAuthenticationContext($this->request, $authorizationUrlOptions);
 
         // The redirect will be handled by this plugin
-        unset($_SESSION['oidc_redirect_url']);
+        $authContext->redirectUrl = '';
 
-        return $authorizationUrl;
+        return $authContext->authorizationUrl;
     }
 
     protected function determineRedirectUrl()

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -84,7 +84,7 @@ class LoginController
         // The redirect will be handled by this plugin
         $authContext->redirectUrl = '';
 
-        return $authContext->authorizationUrl;
+        return $authContext->getAuthorizationUrl();
     }
 
     protected function determineRedirectUrl()

--- a/Classes/EventListener/FrontendLoginEventListener.php
+++ b/Classes/EventListener/FrontendLoginEventListener.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Causal\Oidc\EventListener;
 
 use Causal\Oidc\Service\OpenIdConnectService;
+use InvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -31,8 +32,9 @@ class FrontendLoginEventListener implements LoggerAwareInterface
     {
         $authService = GeneralUtility::makeInstance(OpenIdConnectService::class);
         try {
-            $uri = $authService->generateOpenidConnectUri();
-        } catch (\InvalidArgumentException $e) {
+            $authContext = $authService->generateAuthenticationContext($GLOBALS['TYPO3_REQUEST']);
+            $uri = $authContext->authorizationUrl;
+        } catch (InvalidArgumentException $e) {
             $uri = '#InvalidOIDCConfiguration';
         }
         $event->getView()->assign('openidConnectUri', $uri);

--- a/Classes/EventListener/FrontendLoginEventListener.php
+++ b/Classes/EventListener/FrontendLoginEventListener.php
@@ -33,7 +33,7 @@ class FrontendLoginEventListener implements LoggerAwareInterface
         $authService = GeneralUtility::makeInstance(OpenIdConnectService::class);
         try {
             $authContext = $authService->generateAuthenticationContext($GLOBALS['TYPO3_REQUEST']);
-            $uri = $authContext->authorizationUrl;
+            $uri = $authContext->getAuthorizationUrl();
         } catch (InvalidArgumentException $e) {
             $uri = '#InvalidOIDCConfiguration';
         }

--- a/Classes/Middleware/OauthCallback.php
+++ b/Classes/Middleware/OauthCallback.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Causal\Oidc\Middleware;
 
+use Causal\Oidc\AuthenticationContext;
+use Causal\Oidc\Service\OpenIdConnectService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\HttpFoundation\Cookie;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -19,69 +25,140 @@ class OauthCallback implements MiddlewareInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
+    protected const COOKIE_NAME = 'oidc_context';
+    protected const COOKIE_PREFIX = '';
+    protected const SECURE_PREFIX = '__Secure-';
+
+    protected OpenIdConnectService $openIdConnectService;
+
+    public function __construct(OpenIdConnectService $openIdConnectService)
+    {
+        $this->openIdConnectService = $openIdConnectService;
+    }
+
     /**
      * @param ServerRequestInterface $request
      * @param RequestHandlerInterface $handler
      * @return ResponseInterface
      * see https://github.com/thephpleague/oauth2-client
+     * @throws ExtensionConfigurationExtensionNotConfiguredException
+     * @throws ExtensionConfigurationPathDoesNotExistException
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        $authContext = $this->resolveAuthenticationContext($request);
+        if ($authContext) {
+            $this->openIdConnectService->setAuthenticationContext($authContext);
+            $this->logger->debug('Authentication context is available', [
+                'data' => $authContext,
+            ]);
+        }
+
         $queryParams = $request->getQueryParams();
         $code = $queryParams['code'] ?? '';
         if (!$code) {
-            return $handler->handle($request);
+            $response = $handler->handle($request);
+            return $this->enrichResponseWithCookie($request, $response);
+        }
+        if (!$authContext) {
+            return (new Response())->withStatus(400, 'Missing OIDC authentication context');
         }
 
         // A code was supplied, we start the OIDC handling
+
+        $this->logger->debug('Initiating the silent authentication');
 
         $state = $queryParams['state'] ?? '';
         if (!$state) {
             return (new Response())->withStatus(400, 'Invalid state');
         }
-        $this->logger->debug('Initiating the silent authentication');
-
-        if (session_id() === '') {
-            $this->logger->debug('No PHP session found');
-            session_start();
-        }
-        $this->logger->debug('PHP session is available', [
-            'id' => session_id(),
-            'data' => $_SESSION,
-        ]);
-
-        $stateFromSession = $_SESSION['oidc_state'] ?? null;
-        $loginUrl = $_SESSION['oidc_login_url'] ?? '';
-        $redirectUrlFromSession = $_SESSION['oidc_redirect_url'] ?? '';
-
-        if ($state !== $stateFromSession) {
+        if ($state !== $authContext->state) {
             $globalSettings = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('oidc') ?? [];
             if (!$globalSettings['oidcDisableCSRFProtection']) {
                 $this->logger->error('Invalid returning state detected', [
-                    'expected' => $stateFromSession,
+                    'expected' => $authContext->state,
                     'actual' => $state,
                 ]);
                 return (new Response())->withStatus(400, 'Invalid state');
             }
             $this->logger->info('State mismatch. Bypassing CSRF attack mitigation protection according to the extension configuration', [
-                'expected' => $stateFromSession,
+                'expected' => $authContext->state,
                 'actual' => $state,
             ]);
         }
 
-        $loginUrlParams = [
-            'logintype' => 'login',
-            'tx_oidc' => ['code' => $code],
-        ];
-        if ($redirectUrlFromSession && strpos($loginUrl, 'redirect_url=') === false) {
-            $loginUrlParams['redirect_url'] = $redirectUrlFromSession;
+        $loginUrl = $this->openIdConnectService->getFinalLoginUrl($code);
+
+        $this->logger->info('Redirecting to login URL', ['url' => (string)$loginUrl]);
+
+        return new RedirectResponse(GeneralUtility::locationHeaderUrl((string)$loginUrl), 303);
+    }
+
+    /**
+     * @see \TYPO3\CMS\Core\Middleware\RequestTokenMiddleware::resolveNoncePool (v12+)
+     */
+    protected function resolveAuthenticationContext(ServerRequestInterface $request): ?AuthenticationContext
+    {
+        $secure = $this->isHttps($request);
+        // resolves cookie name dependent on whether TLS is used in request and uses `__Secure-` prefix,
+        // see https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#cookie_prefixes
+        $securePrefix = $secure ? self::SECURE_PREFIX : '';
+        $cookiePrefix = $securePrefix . self::COOKIE_PREFIX;
+        $cookiePrefixLength = strlen($cookiePrefix);
+        $cookies = array_filter(
+            $request->getCookieParams(),
+            static fn($name) => is_string($name) && str_starts_with($name, $cookiePrefix),
+            ARRAY_FILTER_USE_KEY
+        );
+        foreach ($cookies as $name => $value) {
+            $name = substr($name, $cookiePrefixLength);
+            if ($name === self::COOKIE_NAME) {
+                return AuthenticationContext::fromJwt($value);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @see \TYPO3\CMS\Core\Middleware\RequestTokenMiddleware::enrichResponseWithCookie (v12+)
+     */
+    protected function enrichResponseWithCookie(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $authContext = $this->openIdConnectService->getAuthenticationContext();
+        if (!$authContext) {
+            return $response;
         }
 
-        $loginUrl .= strpos($loginUrl, '?') !== false ? '&' : '?';
-        $loginUrl .= ltrim(GeneralUtility::implodeArrayForUrl('', $loginUrlParams), '&');
+        $secure = $this->isHttps($request);
+        $normalizedParams = $request->getAttribute('normalizedParams');
+        $path = $normalizedParams->getSitePath();
+        $securePrefix = $secure ? self::SECURE_PREFIX : '';
+        $cookiePrefix = $securePrefix . self::COOKIE_PREFIX;
 
-        $this->logger->info('Redirecting to login URL', ['url' => $loginUrl]);
+        $createCookie = static fn(string $name, string $value, int $expire): Cookie => new Cookie(
+            $name,
+            $value,
+            $expire,
+            $path,
+            null,
+            $secure,
+            true,
+            false,
+            Cookie::SAMESITE_LAX
+        );
 
-        return new RedirectResponse(GeneralUtility::locationHeaderUrl($loginUrl), 303);
+        $cookies = [];
+        $cookies[] = $createCookie($cookiePrefix . self::COOKIE_NAME, $authContext->toHashSignedJwt(), 0);
+
+        foreach ($cookies as $cookie) {
+            $response = $response->withAddedHeader('Set-Cookie', (string)$cookie);
+        }
+        return $response;
+    }
+
+    protected function isHttps(ServerRequestInterface $request): bool
+    {
+        $normalizedParams = $request->getAttribute('normalizedParams');
+        return $normalizedParams instanceof NormalizedParams && $normalizedParams->isHttps();
     }
 }

--- a/Classes/Middleware/OauthCallback.php
+++ b/Classes/Middleware/OauthCallback.php
@@ -46,6 +46,10 @@ class OauthCallback implements MiddlewareInterface, LoggerAwareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        if ($request->getMethod() !== 'GET') {
+            return $handler->handle($request);
+        }
+
         $authContext = $this->resolveAuthenticationContext($request);
         if ($authContext) {
             $this->openIdConnectService->setAuthenticationContext($authContext);

--- a/Classes/Middleware/OauthCallback.php
+++ b/Classes/Middleware/OauthCallback.php
@@ -49,9 +49,7 @@ class OauthCallback implements MiddlewareInterface, LoggerAwareInterface
         $authContext = $this->resolveAuthenticationContext($request);
         if ($authContext) {
             $this->openIdConnectService->setAuthenticationContext($authContext);
-            $this->logger->debug('Authentication context is available', [
-                'data' => $authContext,
-            ]);
+            $this->logger->debug('Authentication context is available', ['data' => $authContext]);
         }
 
         $queryParams = $request->getQueryParams();
@@ -72,17 +70,17 @@ class OauthCallback implements MiddlewareInterface, LoggerAwareInterface
         if (!$state) {
             return (new Response())->withStatus(400, 'Invalid state');
         }
-        if ($state !== $authContext->state) {
+        if ($state !== $authContext->getState()) {
             $globalSettings = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('oidc') ?? [];
             if (!$globalSettings['oidcDisableCSRFProtection']) {
                 $this->logger->error('Invalid returning state detected', [
-                    'expected' => $authContext->state,
+                    'expected' => $authContext->getState(),
                     'actual' => $state,
                 ]);
                 return (new Response())->withStatus(400, 'Invalid state');
             }
             $this->logger->info('State mismatch. Bypassing CSRF attack mitigation protection according to the extension configuration', [
-                'expected' => $authContext->state,
+                'expected' => $authContext->getState(),
                 'actual' => $state,
             ]);
         }

--- a/Classes/Security/JwtTrait.php
+++ b/Classes/Security/JwtTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\Oidc\Security;
+
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+/**
+ * Trait providing support for JWT using symmetric hash signing.
+ *
+ * The benefit of using a trait in this particular case is, that defaults in `self::class`
+ * (used as a pepper during the singing process) are specific for that a particular implementation.
+ *
+ * @internal
+ *
+ * IMPORTANT: This is a _partial_ copy of \TYPO3\CMS\Core\Security\JwtTrait in TYPO3 v12
+ */
+trait JwtTrait
+{
+    private static function getDefaultSigningAlgorithm(): string
+    {
+        return 'HS256';
+    }
+
+    private static function createSigningKeyFromEncryptionKey(string $pepper = self::class): Key
+    {
+        if ($pepper === '') {
+            $pepper = self::class;
+        }
+        $encryptionKey = $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] ?? '';
+        $keyMaterial = hash('sha256', $encryptionKey) . '/' . $pepper;
+        return new Key($keyMaterial, self::getDefaultSigningAlgorithm());
+    }
+
+    private static function encodeHashSignedJwt(array $payload, Key $key): string
+    {
+        return JWT::encode($payload, $key->getKeyMaterial(), self::getDefaultSigningAlgorithm());
+    }
+
+    /**
+     * @param string $jwt
+     * @param Key $key
+     * @param bool $associative
+     * @return \stdClass|array
+     */
+    private static function decodeJwt(string $jwt, Key $key, bool $associative = false)
+    {
+        $payload = JWT::decode($jwt, $key);
+        return $associative ? json_decode(json_encode($payload), true) : $payload;
+    }
+}

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -17,12 +17,10 @@ declare(strict_types=1);
 
 namespace Causal\Oidc\Service;
 
-use Causal\Oidc\AuthenticationContext;
 use Causal\Oidc\Event\AuthenticationGetUserEvent;
 use Causal\Oidc\Event\AuthenticationPreUserEvent;
 use Causal\Oidc\Event\ModifyResourceOwnerEvent;
 use Causal\Oidc\Event\ModifyUserEvent;
-use Causal\Oidc\Middleware\OauthCallback;
 use InvalidArgumentException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;

--- a/Classes/ViewHelpers/OidcLinkViewHelper.php
+++ b/Classes/ViewHelpers/OidcLinkViewHelper.php
@@ -40,7 +40,7 @@ class OidcLinkViewHelper extends AbstractViewHelper
         $authService = GeneralUtility::makeInstance(OpenIdConnectService::class);
         try {
             $authContext = $authService->generateAuthenticationContext($GLOBALS['TYPO3_REQUEST']);
-            $uri = $authContext->authorizationUrl;
+            $uri = $authContext->getAuthorizationUrl();
         } catch (InvalidArgumentException $e) {
             $uri = '#InvalidOIDCConfiguration';
         }

--- a/Classes/ViewHelpers/OidcLinkViewHelper.php
+++ b/Classes/ViewHelpers/OidcLinkViewHelper.php
@@ -39,7 +39,8 @@ class OidcLinkViewHelper extends AbstractViewHelper
     {
         $authService = GeneralUtility::makeInstance(OpenIdConnectService::class);
         try {
-            $uri = $authService->generateOpenidConnectUri();
+            $authContext = $authService->generateAuthenticationContext($GLOBALS['TYPO3_REQUEST']);
+            $uri = $authContext->authorizationUrl;
         } catch (InvalidArgumentException $e) {
             $uri = '#InvalidOIDCConfiguration';
         }

--- a/README.md
+++ b/README.md
@@ -135,18 +135,3 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['Causal']['Oidc']['writerConfiguration'] = [
 **Hint:** Be sure to read
 [Configuration of the Logging system](https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/Logging/Configuration/Index.html#logging-configuration)
 to fine-tune your configuration on any production website.
-
-## Session handling
-
-This extension is using PHP's native sessions (`$_SESSION`) to store state about
-ongoing authentication attempts.
-
-The following data is stored:
-
-* `oidc_state`
-* `oidc_login_url`
-* `oidc_authorization_url`
-* `oidc_redirect_url`
-* `oidc_code_verifier`
-* `requestId`
-

--- a/Tests/Unit/Service/OpenIdConnectServiceTest.php
+++ b/Tests/Unit/Service/OpenIdConnectServiceTest.php
@@ -17,7 +17,6 @@ class OpenIdConnectServiceTest extends UnitTestCase
     {
         parent::setUp();
         $this->service = new OpenIdConnectService(new OAuthService(), ['dummy']);
-        $this->service->setAuthenticationContext(new AuthenticationContext('', '', '', '', 'https://example.com/redirect'));
     }
 
     /**
@@ -26,7 +25,7 @@ class OpenIdConnectServiceTest extends UnitTestCase
      */
     public function getFinalLoginUrlReturnsExpectedUrl(string $loginUrl, string $expected): void
     {
-        $this->service->getAuthenticationContext()->loginUrl = $loginUrl;
+        $this->service->setAuthenticationContext(new AuthenticationContext('', $loginUrl, '', '', 'https://example.com/redirect'));
         self::assertSame($expected, (string)$this->service->getFinalLoginUrl('somecode'));
     }
 

--- a/Tests/Unit/Service/OpenIdConnectServiceTest.php
+++ b/Tests/Unit/Service/OpenIdConnectServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Causal\Oidc\Tests\Unit\Service;
+
+use Causal\Oidc\AuthenticationContext;
+use Causal\Oidc\Service\OAuthService;
+use Causal\Oidc\Service\OpenIdConnectService;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class OpenIdConnectServiceTest extends UnitTestCase
+{
+    protected OpenIdConnectService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new OpenIdConnectService(new OAuthService(), ['dummy']);
+        $this->service->setAuthenticationContext(new AuthenticationContext('', '', '', '', 'https://example.com/redirect'));
+    }
+
+    /**
+     * @test
+     * @dataProvider getFinalLoginUrlReturnsExpectedUrlDataProvider
+     */
+    public function getFinalLoginUrlReturnsExpectedUrl(string $loginUrl, string $expected): void
+    {
+        $this->service->getAuthenticationContext()->loginUrl = $loginUrl;
+        self::assertSame($expected, (string)$this->service->getFinalLoginUrl('somecode'));
+    }
+
+    public static function getFinalLoginUrlReturnsExpectedUrlDataProvider(): array
+    {
+        return [
+            'default' => [
+                'loginUrl' => 'https://example.com/login',
+                'expected' => 'https://example.com/login?logintype=login&tx_oidc%5Bcode%5D=somecode&redirect_url=https%3A%2F%2Fexample.com%2Fredirect',
+            ],
+            'preserves params' => [
+                'loginUrl' => 'https://example.com/login?otherparam=foo',
+                'expected' => 'https://example.com/login?otherparam=foo&logintype=login&tx_oidc%5Bcode%5D=somecode&redirect_url=https%3A%2F%2Fexample.com%2Fredirect',
+            ],
+            'preserves redirect_url' => [
+                'loginUrl' => 'https://example.com/login?redirect_url=http%3A%2F%2Fexample.com%2Fother',
+                'expected' => 'https://example.com/login?redirect_url=http%3A%2F%2Fexample.com%2Fother&logintype=login&tx_oidc%5Bcode%5D=somecode',
+            ],
+        ];
+    }
+}

--- a/Tests/UnitTests-v10.xml
+++ b/Tests/UnitTests-v10.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+    Boilerplate for a unit test suite setup.
+
+    This file is loosely maintained within TYPO3 testing-framework, extensions
+    are encouraged to not use it directly, but to copy it to an own place,
+    for instance Build/UnitTests.xml.
+    Note UnitTestsBootstrap.php should be copied along the way.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../.Build/vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+         cacheDirectory="../.Build/.phpunit.cache"
+         cacheResult="false"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+>
+    <testsuites>
+        <testsuite name="Unit tests">
+            <directory>Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,6 @@
 			"Causal\\Oidc\\": "Classes/"
 		}
 	},
-	"replace": {
-		"typo3-ter/oidc": "self.version"
-	},
 	"scripts": {
 		"extension-create-libs": [
 			"mkdir -p Libraries/temp",

--- a/composer.json
+++ b/composer.json
@@ -27,18 +27,29 @@
 		"typo3/cms-core": "^11.5",
 		"typo3/cms-frontend": "^11.5",
 		"typo3/cms-felogin": "^11.5",
-		"league/oauth2-client": "^2.7"
+		"league/oauth2-client": "^2.7",
+		"firebase/php-jwt": "^6.10"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^10",
+		"typo3/testing-framework": "7.x-dev",
+		"typo3/minimal": "^11"
 	},
 	"autoload": {
 		"psr-4": {
 			"Causal\\Oidc\\": "Classes/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"Causal\\Oidc\\Tests\\": "Tests/"
+		}
+	},
 	"scripts": {
 		"extension-create-libs": [
 			"mkdir -p Libraries/temp",
 			"[ -f $HOME/.composer/vendor/bin/phar-composer ] || composer global require clue/phar-composer",
-			"if [ ! -f Libraries/league-oauth2-client.phar ]; then cd Libraries/temp && composer require league/oauth2-client=^2.7 && composer config classmap-authoritative true && composer config prepend-autoloader false && composer dump-autoload; fi",
+			"if [ ! -f Libraries/league-oauth2-client.phar ]; then cd Libraries/temp && composer require league/oauth2-client=^2.7 && composer require firebase/php-jwt=^6.10 composer config classmap-authoritative true && composer config prepend-autoloader false && composer dump-autoload; fi",
 			"[ -f Libraries/league-oauth2-client.phar ] || $HOME/.composer/vendor/bin/phar-composer build Libraries/temp/ Libraries/league-oauth2-client.phar",
 			"chmod -x Libraries/*.phar",
 			"rm -rf Libraries/temp"
@@ -58,7 +69,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.1.x-dev"
+			"dev-master": "2.2.x-dev"
 		},
 		"typo3/cms": {
 			"app-dir": ".Build",


### PR DESCRIPTION
In order to support multi-head environments without sticky sessions, the data formerly stored in the PHP session is now stored inside a JWT.

Resolves: #154

Should merge https://github.com/xperseguers/t3ext-oidc/pull/153 first.