### PR TITLE
[TASK] Catch any error that may occur during auth url generation

### DIFF
--- a/Classes/EventListener/FrontendLoginEventListener.php
+++ b/Classes/EventListener/FrontendLoginEventListener.php
@@ -21,6 +21,7 @@ use Causal\Oidc\Service\OpenIdConnectService;
 use InvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\FrontendLogin\Event\ModifyLoginFormViewEvent;
 
@@ -36,6 +37,9 @@ class FrontendLoginEventListener implements LoggerAwareInterface
             $uri = $authContext->getAuthorizationUrl();
         } catch (InvalidArgumentException $e) {
             $uri = '#InvalidOIDCConfiguration';
+        } catch (Throwable $e) {
+            // whatever the provider did wrong (can be connection errors)
+            $uri = '#oidcError';
         }
         $event->getView()->assign('openidConnectUri', $uri);
     }

--- a/Classes/ViewHelpers/OidcLinkViewHelper.php
+++ b/Classes/ViewHelpers/OidcLinkViewHelper.php
@@ -19,6 +19,7 @@ namespace Causal\Oidc\ViewHelpers;
 
 use Causal\Oidc\Service\OpenIdConnectService;
 use InvalidArgumentException;
+use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -43,8 +44,10 @@ class OidcLinkViewHelper extends AbstractViewHelper
             $uri = $authContext->getAuthorizationUrl();
         } catch (InvalidArgumentException $e) {
             $uri = '#InvalidOIDCConfiguration';
+        } catch (Throwable $e) {
+            // whatever the provider did wrong (can be connection errors)
+            $uri = '#oidcError';
         }
-
         return $uri;
     }
 }


### PR DESCRIPTION
The underlying provider may throw arbitrary errors.
Make sure those do not propagate to Frontend.