### PR TITLE
[TASK] Use dedicated route for authorization url

### DIFF
--- a/Classes/EventListener/FrontendLoginEventListener.php
+++ b/Classes/EventListener/FrontendLoginEventListener.php
@@ -18,10 +18,8 @@ declare(strict_types=1);
 namespace Causal\Oidc\EventListener;
 
 use Causal\Oidc\Service\OpenIdConnectService;
-use InvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
-use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\FrontendLogin\Event\ModifyLoginFormViewEvent;
 
@@ -31,16 +29,9 @@ class FrontendLoginEventListener implements LoggerAwareInterface
 
     public function modifyLoginFormView(ModifyLoginFormViewEvent $event): void
     {
-        $authService = GeneralUtility::makeInstance(OpenIdConnectService::class);
-        try {
-            $authContext = $authService->generateAuthenticationContext($GLOBALS['TYPO3_REQUEST']);
-            $uri = $authContext->getAuthorizationUrl();
-        } catch (InvalidArgumentException $e) {
-            $uri = '#InvalidOIDCConfiguration';
-        } catch (Throwable $e) {
-            // whatever the provider did wrong (can be connection errors)
-            $uri = '#oidcError';
+        $uri = GeneralUtility::makeInstance(OpenIdConnectService::class)->getAuthenticationRequestUrl();
+        if ($uri) {
+            $event->getView()->assign('openidConnectUri', (string)$uri);
         }
-        $event->getView()->assign('openidConnectUri', $uri);
     }
 }

--- a/Classes/Middleware/AuthenticationUrlRequest.php
+++ b/Classes/Middleware/AuthenticationUrlRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Causal\Oidc\Middleware;
+
+use Causal\Oidc\Service\OpenIdConnectService;
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Throwable;
+use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Http\Response;
+
+class AuthenticationUrlRequest implements MiddlewareInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    protected OpenIdConnectService $openIdConnectService;
+
+    public function __construct(OpenIdConnectService $openIdConnectService)
+    {
+        $this->openIdConnectService = $openIdConnectService;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     * see https://github.com/thephpleague/oauth2-client
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($request->getMethod() === 'GET' && $this->openIdConnectService->isAuthenticationRequest($request)) {
+            try {
+                $authContext = $this->openIdConnectService->generateAuthenticationContext($request);
+                $uri = $authContext->getAuthorizationUrl();
+                return new RedirectResponse($uri);
+            } catch (InvalidArgumentException|Throwable $e) {
+                // config error or
+                // whatever the provider did wrong (can be connection errors)
+                return (new Response())->withStatus(500, 'Authentication provider error');
+            }
+        }
+        return $handler->handle($request);
+    }
+}

--- a/Classes/ViewHelpers/OidcLinkViewHelper.php
+++ b/Classes/ViewHelpers/OidcLinkViewHelper.php
@@ -18,8 +18,6 @@ declare(strict_types=1);
 namespace Causal\Oidc\ViewHelpers;
 
 use Causal\Oidc\Service\OpenIdConnectService;
-use InvalidArgumentException;
-use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -38,16 +36,7 @@ class OidcLinkViewHelper extends AbstractViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        $authService = GeneralUtility::makeInstance(OpenIdConnectService::class);
-        try {
-            $authContext = $authService->generateAuthenticationContext($GLOBALS['TYPO3_REQUEST']);
-            $uri = $authContext->getAuthorizationUrl();
-        } catch (InvalidArgumentException $e) {
-            $uri = '#InvalidOIDCConfiguration';
-        } catch (Throwable $e) {
-            // whatever the provider did wrong (can be connection errors)
-            $uri = '#oidcError';
-        }
-        return $uri;
+        $uri = GeneralUtility::makeInstance(OpenIdConnectService::class)->getAuthenticationRequestUrl();
+        return (string)$uri;
     }
 }

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -7,8 +7,17 @@ return [
                 'typo3/cms-core/normalized-params-attribute',
             ],
             'before' => [
-                'typo3/cms-frontend/eid'
-            ]
+                'typo3/cms-frontend/eid',
+            ],
+        ],
+        'oidcauthurl' => [
+            'target' => \Causal\Oidc\Middleware\AuthenticationUrlRequest::class,
+            'after' => [
+                'typo3/cms-frontend/site',
+            ],
+            'before' => [
+                'typo3/cms-frontend/authentication',
+            ],
         ],
     ],
 ];

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the authorization server.
 ```html
 <f:if condition="{openidConnectUri}">
     <f:then>
-        <a href="{openidConnectUri}" class="btn btn-default"><span class="fa fa-openid"></span> OpenID Connect</a>
+        <a href="{openidConnectUri}" rel="nofollow" class="btn btn-default"><span class="fa fa-openid"></span> OpenID Connect</a>
     </f:then>
     <f:else>
         Invalid OpenID Connect configuration

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" target-language="de" original="messages" datatype="plaintext" product-name="oidc" date="2023-05-09T13:26:53+02:00">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" target-language="de" original="messages" datatype="plaintext" product-name="oidc" date="2024-06-21T21:43:35+02:00">
 		<header></header>
 		<body>
 			<trans-unit id="fe_groups.tx_oidc_pattern" resname="fe_groups.tx_oidc_pattern">
@@ -18,6 +18,10 @@
 			<trans-unit id="settings.authenticationServiceQuality" resname="settings.authenticationServiceQuality">
 				<source>Authentication service Quality: This is used by TYPO3 if two authentication services have the same priority. Higher number wins.</source>
 				<target>Authentifizierungs-Service Qualität: TYPO3 nutzt diesen Wert, wenn zwei Authentifizierungs-Services die gleiche Priorität besitzen. Höhere Zahl gewinnt.</target>
+			</trans-unit>
+			<trans-unit id="settings.authenticationUrlRoute" resname="settings.authenticationUrlRoute">
+				<source>Route for retrieving the authentication URL of the Identity Provider</source>
+				<target>Route um die Authentifzierungs-URL des Identitäts-Anbieters zu erhalten</target>
 			</trans-unit>
 			<trans-unit id="settings.enableCodeVerifier" resname="settings.enableCodeVerifier">
 				<source>Enable PKCE: Enable PKCE flow. Code challenge and code verifier will be sent along.</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" original="messages" datatype="plaintext" product-name="oidc" date="2023-05-09T13:26:53+02:00">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" original="messages" datatype="plaintext" product-name="oidc" date="2024-06-21T21:43:35+02:00">
 		<header></header>
 		<body>
 			<trans-unit id="fe_groups.tx_oidc_pattern" resname="fe_groups.tx_oidc_pattern">
@@ -14,6 +14,9 @@
 			</trans-unit>
 			<trans-unit id="settings.authenticationServiceQuality" resname="settings.authenticationServiceQuality">
 				<source>Authentication service Quality: This is used by TYPO3 if two authentication services have the same priority. Higher number wins.</source>
+			</trans-unit>
+			<trans-unit id="settings.authenticationUrlRoute" resname="settings.authenticationUrlRoute">
+				<source>Route for retrieving the authentication URL of the Identity Provider</source>
 			</trans-unit>
 			<trans-unit id="settings.enableCodeVerifier" resname="settings.enableCodeVerifier">
 				<source>Enable PKCE: Enable PKCE flow. Code challenge and code verifier will be sent along.</source>

--- a/Resources/Private/Templates/Login/Login.html
+++ b/Resources/Private/Templates/Login/Login.html
@@ -50,14 +50,7 @@
             </label>
         </div>
         <div>
-            <f:if condition="{openidConnectUri}">
-                <f:then>
-                    <a href="{openidConnectUri}" class="btn btn-default"><span class="fa fa-openid"></span> OpenID Connect</a>
-                </f:then>
-                <f:else>
-                    Invalid OpenID Connect configuration
-                </f:else>
-            </f:if>
+            <a href="{openidConnectUri}" rel="nofollow" class="btn btn-default"><span class="fa fa-openid"></span> Login with OpenID Connect</a>
         </div>
 
         <f:if condition="{permaloginStatus} > -1">

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -66,3 +66,6 @@ authenticationServicePriority = 82
 
 # cat=advanced//5; type=int+; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.authenticationServiceQuality
 authenticationServiceQuality = 80
+
+# cat=advanced//6; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.authenticationUrlRoute
+authenticationUrlRoute = oidc/authentication


### PR DESCRIPTION
Instead of always generating an authentication url for every rendering of the oidc button,
create a dedicated route, which will create
the authentication URL on demand and
redirect the user there.

Related #158