### PR TITLE
[BUGFIX] No hash validation for authentication url

### DIFF
--- a/Classes/Service/OpenIdConnectService.php
+++ b/Classes/Service/OpenIdConnectService.php
@@ -73,7 +73,7 @@ class OpenIdConnectService implements LoggerAwareInterface
         $loginUrl = $request->getQueryParams()['login_url'] ?? '';
         $redirectUrl = $request->getQueryParams()['redirect_url'] ?? '';
         $hash = $request->getQueryParams()['validation_hash'] ?? '';
-        if (GeneralUtility::hmac($loginUrl . $redirectUrl, 'oidc') !== $hash) {
+        if (($loginUrl || $redirectUrl) && GeneralUtility::hmac($loginUrl . $redirectUrl, 'oidc') !== $hash) {
             throw new InvalidArgumentException('Invalid query string', 1719003567);
         }
 


### PR DESCRIPTION
Ignore hash validation for authentication url
if neither login nor redirect url are provided.