### PR TITLE
[BUGFIX] LoginController should redirect a logged-in user

### DIFF
--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Causal\Oidc\Controller;
 
 use Causal\Oidc\Service\OpenIdConnectService;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\PropagateResponseException;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -66,8 +67,9 @@ class LoginController
             $this->pluginConfiguration = $pluginConfiguration;
         }
 
+        $context = GeneralUtility::makeInstance(Context::class);
         $loginType = $this->request->getParsedBody()['logintype'] ?? $this->request->getQueryParams()['logintype'] ?? '';
-        if ($loginType === 'login') {
+        if ($loginType === 'login' || $context->getAspect('frontend.user')->isLoggedIn()) {
             $redirectUrl = $this->determineRedirectUrl();
             $this->redirect($redirectUrl);
         }


### PR DESCRIPTION
If a user is already logged in do not restart
the authentication process, but simply redirect
as it would happen after a successful login.

Resolves: #161