### PR TITLE
[BUGFIX] Handle missing language request attribute

### DIFF
--- a/Classes/Service/OpenIdConnectService.php
+++ b/Classes/Service/OpenIdConnectService.php
@@ -37,7 +37,7 @@ class OpenIdConnectService implements LoggerAwareInterface
     public function isAuthenticationRequest(ServerRequestInterface $request): bool
     {
         $language = $request->getAttribute('language');
-        return $request->getUri()->getPath() === $language->getBase()->getPath() . $this->config['authenticationUrlRoute'];
+        return $language && $request->getUri()->getPath() === $language->getBase()->getPath() . $this->config['authenticationUrlRoute'];
     }
 
     public function getAuthenticationRequestUrl(): ?UriInterface


### PR DESCRIPTION
If some weird arbitrary URLs are called
for a website, the language may not be
identified at all.

Adjust the authentication request detection
to cope with this situation.