### PR TITLE
[TASK] Remove fe_login extension from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
 		"ext-json": "*",
 		"typo3/cms-core": "^11.5 || ^12.4",
 		"typo3/cms-frontend": "^11.5 || ^12.4",
-		"typo3/cms-felogin": "^11.5 || ^12.4",
 		"league/oauth2-client": "^2.7",
 		"firebase/php-jwt": "^6.10"
 	},


### PR DESCRIPTION
This oidc extension is not dependent on the fe_login extension.