### PR TITLE
[BUGFIX] Use self:: instead of static:: late binding for private constants

### DIFF
--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -280,15 +280,15 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
         // missing access token means the actual OIDC authentication step in the `getUser` method failed
         // or has neven been executed, if the user was discovered by some other authentication service
         if (!isset($user['accessToken'])) {
-            return static::STATUS_AUTHENTICATION_FAILURE_CONTINUE;
+            return self::STATUS_AUTHENTICATION_FAILURE_CONTINUE;
         }
 
         // this is not a valid user authenticated via OIDC
         if (empty($user['tx_oidc'])) {
-            return static::STATUS_AUTHENTICATION_FAILURE_CONTINUE;
+            return self::STATUS_AUTHENTICATION_FAILURE_CONTINUE;
         }
 
-        return static::STATUS_AUTHENTICATION_SUCCESS_BREAK;
+        return self::STATUS_AUTHENTICATION_SUCCESS_BREAK;
     }
 
     /**


### PR DESCRIPTION
Class constants are marked `private` but consuming code uses late static binding with `static::` to access them. Since the constants are private, late static binding makes no sense (no subclass would be able to use the constants) and simply causes an error (access to undefined constant). This patch prevents that error from happening in e.g. https://github.com/georgringer/oidc-be.

There are two ways to solve this:

* Declare the constants `protected` or `public`.
* Or do not use late static binding.

I've chosen the latter in this case since there will not be a need to change the values of these constants or access them externally. Any subclass that chooses to override the method that does use the constants will have to return these values in another way or call the `parent::` method to perform the initial validation and get a return code based on the constants.