### PR TITLE
[TASK] Use v2.8 of league/oauth2-client

### DIFF
--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -115,13 +115,7 @@ class OAuthService
             $options = [
                 'username' => $codeOrUsername,
                 'password' => $password,
-                'scope' => $this->settings['oidcClientScopes'],
             ];
-            // The GenericProvider has this as a public function (contrary to the interface),
-            // so we use its scopes instead as there might be some modified provider.
-            if (is_callable([$this->getProvider(), 'getDefaultScopes'])) {
-                $options['scope'] = implode(',', $this->getProvider()->getDefaultScopes());
-            }
             $grant = new Password();
         }
         return $this->getProvider()->getAccessToken($grant, $options);
@@ -132,9 +126,7 @@ class OAuthService
      */
     public function getAccessTokenForClient(): AccessTokenInterface
     {
-        return $this->getProvider()->getAccessToken('client_credentials', [
-            'scope' => implode(',', $this->getProvider()->getDefaultScopes()),
-        ]);
+        return $this->getProvider()->getAccessToken('client_credentials');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"ext-json": "*",
 		"typo3/cms-core": "^11.5 || ^12.4",
 		"typo3/cms-frontend": "^11.5 || ^12.4",
-		"league/oauth2-client": "^2.7",
+		"league/oauth2-client": "^2.8",
 		"firebase/php-jwt": "^6.10"
 	},
 	"require-dev": {


### PR DESCRIPTION
This adds support for new PHP versions and
fixes the issue with missing scopes
in AbstractProvider::getAccessToken.