### PR TITLE
preserve user email on update configurable

### DIFF
--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -378,7 +378,10 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
         // preserve username and password for existing users
         if ($row) {
             unset($data['username']);
-            unset($data['email']);
+            $preserve = $this->config['preserveUserEmail'] ?? true;
+            if($preserve) {
+                unset($data['email']);
+            }
             unset($data['password']);
         }
 

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -27,6 +27,10 @@
 				<source>Enable PKCE: Enable PKCE flow. Code challenge and code verifier will be sent along.</source>
 				<target>PKCE aktivieren: Aktiviert den PKCE-Fluss. Code-Challenge und Code-Verifier werden mitgeschickt.</target>
 			</trans-unit>
+			<trans-unit id="settings.preserveUserEmail" resname="settings.preserveUserEmail">
+				<source>Preserve User E-Mail in Database. If ticked, the E-Mail in the local Database will not be updated on Login.</source>
+				<target>E-Mail des Benutzers in der Datenbank beibehalten. Wenn aktiviert, wird die E-Mail in der lokalen Datenbank beim Login nicht aktualisiert.</target>
+			</trans-unit>
 			<trans-unit id="settings.enableFrontendAuthentication" resname="settings.enableFrontendAuthentication">
 				<source>Frontend Authentication: Enable OpenID Connect authentication for the frontend.</source>
 				<target>Frontend-Authentifizierung: Aktivieren Sie die OpenID Connect-Authentifizierung für das Frontend.</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -21,6 +21,9 @@
 			<trans-unit id="settings.enableCodeVerifier" resname="settings.enableCodeVerifier">
 				<source>Enable PKCE: Enable PKCE flow. Code challenge and code verifier will be sent along.</source>
 			</trans-unit>
+			<trans-unit id="settings.preserveUserEmail" resname="settings.preserveUserEmail">
+				<source>Preserve User E-Mail in Database. If ticked, the E-Mail in the local Database will not be updated on Login.</source>
+			</trans-unit>
 			<trans-unit id="settings.enableFrontendAuthentication" resname="settings.enableFrontendAuthentication">
 				<source>Frontend Authentication: Enable OpenID Connect authentication for the frontend.</source>
 			</trans-unit>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,6 +13,9 @@ frontendUserMustExistLocally = 0
 # cat=basic/enable/5; type=boolean; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.enableCodeVerifier
 enableCodeVerifier = 0
 
+# cat=basic/enable/6; type=boolean; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.preserveUserEmail
+preserveUserEmail = 0
+
 # cat=basic//1; type=int; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.usersStoragePid
 usersStoragePid =
 


### PR DESCRIPTION
# Current behavior

- User is created
- email is stored
- During sync on login, email is explicitly excluded

# Problem

In the AuthenticationService, the user’s email is not being updated during login (lines 378–383). As a result, the email of a user cannot be changed after their first login when user management is handled by the OpenID server.

# Solution

The preservation of the email can now be controlled via a new setting in the extension configuration. If the setting is not enabled, the behavior remains unchanged, and the email is preserved.
