### PR TITLE
[!!!][BUGFIX] Allow username and email to be updated upon login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OpenID Connect integration for TYPO3 - changelog
 
+## Version 4.x.x
+
+- Breaking: Upon login the user's username and email address will now be updated
+  according to the mapping configuration. The default mapping configuration maps
+  the username, but not the email address. Custom mapping configurations can now
+  map none, one or both of those fields.
+  It is now possible to post-process the mapping by ìmplementing the `AuthenticationProcessMappingEvent`
+
 ## Version 3.0.0
 
 - The callback URL changed from `/typo3conf/ext/oidc/Public/callback.php` to `TYPO3_SITE_URL`. (configurable with option `oidcRedirectUri`) [#116](https://github.com/xperseguers/t3ext-oidc/issues/116)

--- a/Classes/Event/AuthenticationProcessMappingEvent.php
+++ b/Classes/Event/AuthenticationProcessMappingEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\Oidc\Event;
+
+use Psr\Http\Message\RequestInterface;
+
+final class AuthenticationProcessMappingEvent
+{
+    public function __construct(
+        public readonly RequestInterface $request,
+        public readonly string $databaseTable,
+        public readonly array $existingUser,
+        public readonly array $resourceOwner,
+        public array $mappedData,
+    ) {}
+}


### PR DESCRIPTION
Username and email address are now updated
when provided via mapping from IdP.

For cases where this is not desired,
a new MappingEvent is available, where
this behavior can be adjusted.

Resolves: #189