### PR TITLE
[TASK #197] add DI for FrontendSimulationV13

### DIFF
--- a/Classes/Frontend/FrontendSimulationV13.php
+++ b/Classes/Frontend/FrontendSimulationV13.php
@@ -23,6 +23,13 @@ use TYPO3\CMS\Frontend\Page\PageInformationFactory;
 
 class FrontendSimulationV13 extends FrontendSimulationV12
 {
+
+    public function __construct(
+        protected PageInformationFactory $pageInformationFactory,
+        protected FrontendTypoScriptFactory $frontendTypoScriptFactory,
+    ) {
+    }
+
     public function getTSFE(ServerRequestInterface $originalRequest): TypoScriptFrontendController
     {
         return GeneralUtility::makeInstance(TypoScriptFrontendController::class);
@@ -46,8 +53,7 @@ class FrontendSimulationV13 extends FrontendSimulationV12
                     $pageArguments = $site->getRouter()->matchRequest($originalRequest, $routeResult);
                     $originalRequest = $originalRequest->withAttribute('routing', $pageArguments);
 
-                    $pageInformationFactory = GeneralUtility::makeInstance(PageInformationFactory::class);
-                    $pageInformation = $pageInformationFactory->create($originalRequest);
+                    $pageInformation = $this->pageInformationFactory->create($originalRequest);
                     $originalRequest = $originalRequest->withAttribute('frontend.page.information', $pageInformation);
 
                     $expressionMatcherVariables = $this->getExpressionMatcherVariables($site, $originalRequest, $tsfe);
@@ -56,15 +62,14 @@ class FrontendSimulationV13 extends FrontendSimulationV12
                     /** @var PhpFrontend $cache */
                     $cache = $cacheManager->getCache('typoscript');
 
-                    $frontendTypoScriptFactory = GeneralUtility::makeInstance(FrontendTypoScriptFactory::class);
-                    $frontendTypoScript = $frontendTypoScriptFactory->createSettingsAndSetupConditions(
+                    $frontendTypoScript = $this->frontendTypoScriptFactory->createSettingsAndSetupConditions(
                         $site,
                         $pageInformation->getSysTemplateRows(),
                         // $originalRequest does not contain site ...
                         $expressionMatcherVariables,
                         $cache,
                     );
-                    $frontendTypoScript = $frontendTypoScriptFactory->createSetupConfigOrFullSetup(
+                    $frontendTypoScript = $this->frontendTypoScriptFactory->createSetupConfigOrFullSetup(
                         true,
                         $frontendTypoScript,
                         $site,

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -32,6 +32,9 @@ services:
         identifier: 'causal/oidc-request-token'
         event: TYPO3\CMS\Core\Authentication\Event\BeforeRequestTokenProcessedEvent
 
+  Causal\Oidc\Frontend\FrontendSimulationV13:
+    public: true
+
   Causal\Oidc\EventListener\GetAuthorizationUrlSetLanguageEventListener:
     tags:
       - name: event.listener


### PR DESCRIPTION
reaplaced the GenerUtility::makeInstance stuff with constructor DI in FrontendSimulationV13. This fixes the issue #197. Tested only on TYPO3 13! But maybe this helps!