### PR TITLE
[BUGFIX] Fix DI error in TYPO3 v12 #203

### DIFF
--- a/Classes/Frontend/FrontendSimulationV13.php
+++ b/Classes/Frontend/FrontendSimulationV13.php
@@ -23,13 +23,6 @@ use TYPO3\CMS\Frontend\Page\PageInformationFactory;
 
 class FrontendSimulationV13 extends FrontendSimulationV12
 {
-
-    public function __construct(
-        protected PageInformationFactory $pageInformationFactory,
-        protected FrontendTypoScriptFactory $frontendTypoScriptFactory,
-    ) {
-    }
-
     public function getTSFE(ServerRequestInterface $originalRequest): TypoScriptFrontendController
     {
         return GeneralUtility::makeInstance(TypoScriptFrontendController::class);
@@ -53,7 +46,8 @@ class FrontendSimulationV13 extends FrontendSimulationV12
                     $pageArguments = $site->getRouter()->matchRequest($originalRequest, $routeResult);
                     $originalRequest = $originalRequest->withAttribute('routing', $pageArguments);
 
-                    $pageInformation = $this->pageInformationFactory->create($originalRequest);
+                    $pageInformationFactory = GeneralUtility::makeInstance(PageInformationFactory::class);
+                    $pageInformation = $pageInformationFactory->create($originalRequest);
                     $originalRequest = $originalRequest->withAttribute('frontend.page.information', $pageInformation);
 
                     $expressionMatcherVariables = $this->getExpressionMatcherVariables($site, $originalRequest, $tsfe);
@@ -62,14 +56,15 @@ class FrontendSimulationV13 extends FrontendSimulationV12
                     /** @var PhpFrontend $cache */
                     $cache = $cacheManager->getCache('typoscript');
 
-                    $frontendTypoScript = $this->frontendTypoScriptFactory->createSettingsAndSetupConditions(
+                    $frontendTypoScriptFactory = GeneralUtility::makeInstance(FrontendTypoScriptFactory::class);
+                    $frontendTypoScript = $frontendTypoScriptFactory->createSettingsAndSetupConditions(
                         $site,
                         $pageInformation->getSysTemplateRows(),
                         // $originalRequest does not contain site ...
                         $expressionMatcherVariables,
                         $cache,
                     );
-                    $frontendTypoScript = $this->frontendTypoScriptFactory->createSetupConfigOrFullSetup(
+                    $frontendTypoScript = $frontendTypoScriptFactory->createSetupConfigOrFullSetup(
                         true,
                         $frontendTypoScript,
                         $site,

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -32,11 +32,16 @@ services:
         identifier: 'causal/oidc-request-token'
         event: TYPO3\CMS\Core\Authentication\Event\BeforeRequestTokenProcessedEvent
 
-  Causal\Oidc\Frontend\FrontendSimulationV13:
-    public: true
-
   Causal\Oidc\EventListener\GetAuthorizationUrlSetLanguageEventListener:
     tags:
       - name: event.listener
         identifier: 'causal/oidc-get-authorization-url-set-language'
         event: Causal\Oidc\Event\GetAuthorizationUrlEvent
+
+
+
+  # Causal\Oidc\Frontend\FrontendSimulationV13 instantiates two internal core classes via GeneralUtility::makeInstance
+  TYPO3\CMS\Frontend\Page\PageInformationFactory:
+    public: true
+  TYPO3\CMS\Core\TypoScript\FrontendTypoScriptFactory:
+    public: true


### PR DESCRIPTION
Fix an error where TYPO3 v12 was unable to build its DI container due to oidc dependencies on non-existent core classes.

Declare core-internal classes as public via Services.yaml Instantiate the core-internal classes via GeneralUtility::makeInstance