### PR TITLE
[BUGFIX] Exclude tx_oidc[code] parameter from cHash

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	"require": {
 		"php": "^8.2",
 		"ext-json": "*",
-		"typo3/cms-core": "^12.4 || ^13.4",
+		"typo3/cms-core": "^12.4.33 || ^13.4.14",
 		"typo3/cms-frontend": "^12.4 || ^13.4",
 		"league/oauth2-client": "^2.8",
 		"firebase/php-jwt": "^6.10"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -12,6 +12,8 @@ defined('TYPO3') or die();
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = DataHandlerOidc::class;
 
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'tx_oidc[code]';
+
 $settings = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('oidc') ?? [];
 
 // Service configuration


### PR DESCRIPTION
Together with TYPO3 core fix
https://forge.typo3.org/issues/106835
the logintype and tx_oidc[code] parameters are
now excluded from cHash calculation.

Resolves: #202