### PR TITLE
[TASK] Log errors caused by AuthenticationUrlRequest middleware

### DIFF
--- a/Classes/Middleware/AuthenticationUrlRequest.php
+++ b/Classes/Middleware/AuthenticationUrlRequest.php
@@ -40,10 +40,11 @@ class AuthenticationUrlRequest implements MiddlewareInterface, LoggerAwareInterf
                 $authContext = $this->openIdConnectService->generateAuthenticationContext($request);
                 $uri = $authContext->getAuthorizationUrl();
                 return new RedirectResponse($uri);
-            } catch (InvalidArgumentException|Throwable) {
+            } catch (InvalidArgumentException|Throwable $e) {
+                $this->logger->alert('OIDC authentication provider error', ['exception' => $e]);
                 // config error or
                 // whatever the provider did wrong (can be connection errors)
-                return (new Response())->withStatus(500, 'Authentication provider error');
+                return (new Response())->withStatus(500)->withHeader('x-reason', 'Authentication provider error');
             }
         }
         return $handler->handle($request);


### PR DESCRIPTION
If the actual provider throws some error
this would have been hidden behind the 500
status response.

Add dedicated logging for such errors.
Additionally, send the error reason as
HTTP header, since the "reason phrase" of
the status code is ignored since HTTP/2