### PR TITLE
ROLES should be configurable in extension settings

### DIFF
--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -13,7 +13,17 @@ $tempColumns = [
             'readOnly' => !($settings['frontendUserMustExistLocally'] ?? ''),
         ]
     ],
+     'tx_oidc_info' => [
+        'exclude' => 1,
+        'label' => 'LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:fe_users.tx_oidc_info',
+        'config' => [
+            'type' => 'text',
+            'cols' => 30,
+            'rows' => 6,
+            'readOnly' => 1,
+        ]
+    ],
 ];
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('fe_users', $tempColumns);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('fe_users', 'tx_oidc');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('fe_users', '--div--;OpenID Connect,tx_oidc, tx_oidc_info');

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -10,6 +10,10 @@
 				<source>OpenID Connect Identifier</source>
 				<target>OpenID Connect Identifier</target>
 			</trans-unit>
+            <trans-unit id="fe_users.tx_oidc_info">
+				<source>OpenID Connect Info</source>
+                <target>OpenID Connect Info</target>
+			</trans-unit>
 			<trans-unit id="settings.authenticationServicePriority">
 				<source>Authentication service priority: This defines the order of the OIDC authentication service in relation to other authentication services. Higher number wins.</source>
 				<target>Authentifizierungs-Service Priorität: Definiert die Reihenfolge des OIDC Authentifizierungs-Service in Bezug auf andere Authentifizierungs-Services. Höhere Zahl gewinnt.</target>
@@ -109,6 +113,10 @@
 			<trans-unit id="tt_content.oidc_login">
 				<source>OIDC Login</source>
 				<target>OIDC-Anmeldung</target>
+			</trans-unit>
+            <trans-unit id="settings.feUserRoles">
+                <source>Default user roles (comma-separated list of roles)</source>
+				<target>Standard Rollen für Web-Benutzer (CSV Liste)</target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -8,6 +8,9 @@
 			<trans-unit id="fe_users.tx_oidc">
 				<source>OpenID Connect Identifier</source>
 			</trans-unit>
+            <trans-unit id="fe_users.tx_oidc_info">
+				<source>OpenID Connect Info</source>
+			</trans-unit>
 			<trans-unit id="settings.authenticationServicePriority">
 				<source>Authentication service priority: This defines the order of the OIDC authentication service in relation to other authentication services. Higher number wins.</source>
 			</trans-unit>
@@ -76,6 +79,9 @@
 			</trans-unit>
 			<trans-unit id="settings.usersDefaultGroup">
 				<source>Default user group(s) (comma-separated list of UIDs)</source>
+			</trans-unit>
+            <trans-unit id="settings.feUserRoles">
+				<source>Default user roles (comma-separated list of roles)</source>
 			</trans-unit>
 			<trans-unit id="settings.usersStoragePid">
 				<source>Storage Pid: Comma-separated list of page UIDs where fe_users are located. The first UID is used to store new users.</source>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -19,6 +19,9 @@ usersStoragePid =
 # cat=basic//2; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.usersDefaultGroup
 usersDefaultGroup =
 
+# cat=basic//2; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.feUserRoles
+feUserRoles = Roles
+
 # cat=basic//2a; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcRedirectUri
 oidcRedirectUri =
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,6 +1,7 @@
 CREATE TABLE fe_users
 (
 	tx_oidc varchar(100) DEFAULT '' NOT NULL,
+    tx_oidc_info text DEFAULT '' NOT NULL
 
 	KEY fk_oidc (tx_oidc)
 );


### PR DESCRIPTION
[FEATURE] ROLES should be configurable in extension settings. A new field "tx_oidc_info" has been added to the "fe_users" table, where the entire object is stored as JSON.