### PR TITLE
[BUGFIX] Deal with non-public internal TYPO3 services

### DIFF
--- a/Classes/Frontend/FrontendSimulationV12.php
+++ b/Classes/Frontend/FrontendSimulationV12.php
@@ -6,6 +6,7 @@ namespace Causal\Oidc\Frontend;
 
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Routing\RouteNotFoundException;
@@ -17,6 +18,15 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
+/**
+ * Provide {@see FrontendSimulationInterface} implementation compatible for TYPO3 v12.
+ *
+ * Note that `#[Exclude]` is used intentionally to avoid automatic early compiling into the
+ * dependency injection container leading to missing class and other issues for not related
+ * TYPO3 version. TYPO3 version aware configuration is handled and re_enabled within the
+ * `EXT:oidc/Configuration/Services.php` file.
+ */
+#[Exclude]
 class FrontendSimulationV12 implements FrontendSimulationInterface
 {
     public function getTSFE(ServerRequestInterface $originalRequest): TypoScriptFrontendController
@@ -60,7 +70,6 @@ class FrontendSimulationV12 implements FrontendSimulationInterface
         /** @var Context $context */
         $context = GeneralUtility::makeInstance(Context::class);
         $context->unsetAspect('typoscript');
-        $context->unsetAspect('frontend.preview');
         unset($GLOBALS['TSFE']);
     }
 }

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -25,8 +25,6 @@ use Causal\Oidc\Event\AuthenticationProcessMappingEvent;
 use Causal\Oidc\Event\ModifyResourceOwnerEvent;
 use Causal\Oidc\Event\ModifyUserEvent;
 use Causal\Oidc\Frontend\FrontendSimulationInterface;
-use Causal\Oidc\Frontend\FrontendSimulationV12;
-use Causal\Oidc\Frontend\FrontendSimulationV13;
 use Causal\Oidc\OidcConfiguration;
 use InvalidArgumentException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
@@ -45,7 +43,6 @@ use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction;
 use TYPO3\CMS\Core\Http\ServerRequestFactory;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use UnexpectedValueException;
@@ -699,13 +696,7 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
 
     protected function getFrontendSimulation(): FrontendSimulationInterface
     {
-        $typo3Version = (new Typo3Version())->getMajorVersion();
-        if ($typo3Version === 13) {
-            $feSim = GeneralUtility::makeInstance(FrontendSimulationV13::class);
-        } else {
-            $feSim = GeneralUtility::makeInstance(FrontendSimulationV12::class);
-        }
-        return $feSim;
+        return GeneralUtility::makeInstance(FrontendSimulationInterface::class);
     }
 
     /**

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,0 +1,40 @@
+<?php
+
+use Causal\Oidc\Frontend\FrontendSimulationInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\TypoScript\FrontendTypoScriptFactory;
+use TYPO3\CMS\Frontend\Page\PageInformationFactory;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (
+    ContainerConfigurator $configurator,
+    ContainerBuilder $builder,
+) {
+    // We retrieve the services class.
+    $services = $configurator->services();
+
+    // Ensure to make only the concrete frontend simulation for current used TYPO3 version
+    // available in the dependency container. Additionally we create an alias for to the
+    // version related implementation for `FrontendSimulationInterface` allowing to use
+    // the interface to get the suiting implementation for current core usage injected or
+    // retrieved using `GeneralUtility::makeInstance(FrontendSimulationInterface::class)`.
+    $typo3MajorVersion = (new Typo3Version())->getMajorVersion();
+    $frontendSimulationClassName = sprintf(
+        'Causal\\Oidc\\Frontend\\FrontendSimulationV%s',
+        $typo3MajorVersion,
+    );
+    $services->set($frontendSimulationClassName)->autoconfigure()->autowire()->public();
+    $services->alias(FrontendSimulationInterface::class, service($frontendSimulationClassName))->public();
+
+    // Make internal TYPO3 v13 services public so that they can be retrieved with `GeneralUtility::makeInstance()`,
+    // which is required for `FrontendSimulationV13` implementation to pull them instead of getting them injected.
+    if (class_exists(PageInformationFactory::class)) {
+        $builder->findDefinition(PageInformationFactory::class)->setPublic(true);
+    }
+    if (class_exists(FrontendTypoScriptFactory::class)) {
+        $builder->findDefinition(FrontendTypoScriptFactory::class)->setPublic(true);
+    }
+};

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -36,11 +36,3 @@ services:
       - name: event.listener
         identifier: 'causal/oidc-get-authorization-url-set-language'
         event: Causal\Oidc\Event\GetAuthorizationUrlEvent
-
-
-
-  # Causal\Oidc\Frontend\FrontendSimulationV13 instantiates two internal core classes via GeneralUtility::makeInstance
-  TYPO3\CMS\Frontend\Page\PageInformationFactory:
-    public: true
-  TYPO3\CMS\Core\TypoScript\FrontendTypoScriptFactory:
-    public: true


### PR DESCRIPTION
TYPO3 v13 requires some services to create frontend
environment which are not made public by the core,
mainly because they are injected and due to the
`@internal` flag no need to do it so.

To understand the strategy used in this change it's
important to know in which steps the DI container
is created in TYPO3, which is literally following:

* `ServiceProvider` for lowlevel/failsafe container
  to make services available also in `EXT:install`
  context. This is not documented and communicated,
  considered mainly for TYPO3 internal usage. This
  provides factories and extension available in
  failsafe and not failsave container context and
  everything below only for non-failsafe context.

* Iterate over `Configuration/Services.yaml` files
  from TYPO3 extensions, and based on the provided
  resources first respect and configurate definitions
  based on php attributes and manually based on
  entries in the file.

* Iterate over `Configuration/Services.php` files
  from TYPO3 extensions, and based on eventually
  included resource path load definitions scan
  PHP attributes again to estend/replace service
  definitions and directly added definitions. As
  this is executed code conditional registrations
  can be done using PHP functionalites, for example
  using `class_exist()` checks.

This change uses following strategies to prepare
the frontend simulation for dependency injection
while keeping it compatible with multiple TYPO3
versions:

* Adding `#[Exclude]` to the TYPO3 version depending
  implementation to keep them included.

* Introdcing the `Configuration/Services.php` file to
  make version based conditional service configuration
  possible:

  - Allow `autoconfiguration` and `autowiring` only
    for the Frontend Simulation class suitable for
    the current installed TYPO3 version and make it
    public retrieveable from the DI container, for
    example using `GeneralUtility::makeInstance()`.

  - Set an alias for the `FrontendSimulationInterface`
    to the version related implementation service and
    make it public instanciable, which allows to use
    the interface for `constructor` or `inject-method`
    dependency injection in the future and allow to
    retrieve it using

    ```php
    $frontendSimulation = GeneralUtility::makeInstance(
      FrontendSimulationInterface::class
    );
    ```

  - Reconfigure the definition for TYPO3 v13 services
    only on v13 using `class_exist()` checks to make
    them public retrieveable.

  - `FrontendSimulationv13` no longer extends the
    `FrontendSimulationv12` class and implements
    the interface now, which required that method
    `cleanupTSFE()` has been cloned and unsetting
    the TYPO3 v12 typoscript context aspect removed.

  - `FrontendSimulationv12::cleanupTSFE()` has been
    modified and the TYPO3 v13 `frontend.preview`
    context is no longer unset.

  - `AuthenticationService::getFrontendSimulation()` has been
    streamlined to use the `FrontendSimulationInterface` to
    retrieve the suitable implementation for current TYPO3
    versions allowing to remove TYPO3 Version related code
    here and some use import statements.

Resolves: #231
