### PR TITLE
[TASK] Blind configuration secrets

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -45,7 +45,7 @@ return (new \PhpCsFixer\Config())
         'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
         'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
         'php_unit_mock_short_will_return' => true,
-        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self', 'target' => '10.0'],
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_scalar' => true,

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -122,7 +122,9 @@ namespace PHPSTORM_META {
         'moduleData' => \TYPO3\CMS\Backend\Module\ModuleData::class,
     ]));
 
-    override(\TYPO3\CMS\Core\Routing\SiteMatcher::matchRequest(), type(
+    override(
+        \TYPO3\CMS\Core\Routing\SiteMatcher::matchRequest(),
+        type(
             \TYPO3\CMS\Core\Routing\SiteRouteResult::class,
             \TYPO3\CMS\Core\Routing\RouteResultInterface::class,
         )
@@ -142,6 +144,6 @@ namespace PHPSTORM_META {
     ]));
 
     override(\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(0), map([
-        '' => '@'
+        '' => '@',
     ]));
 }

--- a/Classes/EventListener/ModifyBlindedConfigurationOptionsListener.php
+++ b/Classes/EventListener/ModifyBlindedConfigurationOptionsListener.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Causal\Oidc\EventListener;
+
+use TYPO3\CMS\Lowlevel\Event\ModifyBlindedConfigurationOptionsEvent;
+
+final class ModifyBlindedConfigurationOptionsListener
+{
+    public function __invoke(ModifyBlindedConfigurationOptionsEvent $event): void
+    {
+        $options = $event->getBlindedConfigurationOptions();
+        if ($event->getProviderIdentifier() === 'confVars') {
+            $options['TYPO3_CONF_VARS']['EXTENSIONS']['oidc']['oidcClientKey']
+                = substr($options['TYPO3_CONF_VARS']['EXTENSIONS']['oidc']['oidcClientKey'], 0, 3) . '******';
+            $options['TYPO3_CONF_VARS']['EXTENSIONS']['oidc']['oidcClientSecret']
+                = substr($options['TYPO3_CONF_VARS']['EXTENSIONS']['oidc']['oidcClientSecret'], 0, 3) . '******';
+        }
+
+        $event->setBlindedConfigurationOptions($options);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -37,7 +37,10 @@ services:
         identifier: 'causal/oidc-get-authorization-url-set-language'
         event: Causal\Oidc\Event\GetAuthorizationUrlEvent
 
-
+  Causal\Oidc\EventListener\ModifyBlindedConfigurationOptionsListener:
+    tags:
+      - name: event.listener
+        identifier: 'causal/blind-configuration-options'
 
   # Causal\Oidc\Frontend\FrontendSimulationV13 instantiates two internal core classes via GeneralUtility::makeInstance
   TYPO3\CMS\Frontend\Page\PageInformationFactory:

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
 		"guzzlehttp/psr7": "^2.4",
 		"typo3/cms-core": "^12.4.33 || ^13.4.14",
 		"typo3/cms-frontend": "^12.4 || ^13.4",
+		"typo3/cms-lowlevel": "^12.4 || ^13.4",
 		"symfony/http-foundation": "^7",
 		"league/oauth2-client": "^2.8",
 		"firebase/php-jwt": "^6.10"


### PR DESCRIPTION
Hide most of the values of oidcClientKey and oidcClientSecret in BE output.

Uses the ModifyBlindedConfigurationOptionsEvent.

Resolves: #235