### PR TITLE
[FEATURE] Add OIDC Discovery Endpoint and PKCE public client support

### DIFF
--- a/Classes/Factory/GenericOAuthProviderFactory.php
+++ b/Classes/Factory/GenericOAuthProviderFactory.php
@@ -31,10 +31,17 @@ final readonly class GenericOAuthProviderFactory implements OAuthProviderFactory
             'requestFactory' => $this->requestFactory,
         ];
 
+        $clientSecret = $settings->oidcClientSecret;
+
+        // PKCE public client: no client secret required
+        if ($settings->enableCodeVerifier && $clientSecret === '') {
+            $clientSecret = '';
+        }
+
         return new GenericOpenIdProvider(
             [
                 'clientId' => $settings->oidcClientKey,
-                'clientSecret' => $settings->oidcClientSecret,
+                'clientSecret' => $clientSecret,
                 'redirectUri' => $settings->oidcRedirectUri,
                 'urlAuthorize' => $settings->endpointAuthorize,
                 'urlAccessToken' => $settings->endpointToken,

--- a/Classes/OidcConfiguration.php
+++ b/Classes/OidcConfiguration.php
@@ -7,6 +7,7 @@ namespace Causal\Oidc;
 use Causal\Oidc\Factory\GenericOAuthProviderFactory;
 use Causal\Oidc\Factory\OAuthProviderFactoryInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class OidcConfiguration
@@ -39,6 +40,19 @@ final class OidcConfiguration
     public string $endpointLogout = '';
     public bool $revokeAccessTokenAfterLogin = false;
     public bool $enablePasswordCredentials = false;
+    public string $oidcDiscoveryUrl = '';
+
+    /**
+     * OIDC Discovery document mapping:
+     * discovery key => property name
+     */
+    private const DISCOVERY_MAP = [
+        'authorization_endpoint' => 'endpointAuthorize',
+        'token_endpoint'         => 'endpointToken',
+        'userinfo_endpoint'      => 'endpointUserInfo',
+        'end_session_endpoint'   => 'endpointLogout',
+        'revocation_endpoint'    => 'endpointRevoke',
+    ];
 
     public function __construct(array $extConfig = [])
     {
@@ -70,6 +84,93 @@ final class OidcConfiguration
         $this->oidcRedirectUri = $extConfig['oidcRedirectUri'];
         $this->revokeAccessTokenAfterLogin = (bool)$extConfig['oidcRevokeAccessTokenAfterLogin'];
         $this->enablePasswordCredentials = (bool)($extConfig['enablePasswordCredentials'] ?? $this->enablePasswordCredentials);
+        $this->oidcDiscoveryUrl = trim((string)($extConfig['oidcDiscoveryUrl'] ?? ''));
+
+        $this->applyDiscovery();
+    }
+
+    /**
+     * If oidcDiscoveryUrl is set and any endpoint is empty,
+     * fetch the OIDC discovery document and fill in the blanks.
+     * Manually configured endpoints always take precedence.
+     */
+    private function applyDiscovery(): void
+    {
+        if ($this->oidcDiscoveryUrl === '') {
+            return;
+        }
+
+        $needsDiscovery = false;
+        foreach (self::DISCOVERY_MAP as $property) {
+            if ($this->{$property} === '') {
+                $needsDiscovery = true;
+                break;
+            }
+        }
+
+        if (!$needsDiscovery) {
+            return;
+        }
+
+        try {
+            $document = $this->fetchDiscoveryDocument($this->oidcDiscoveryUrl);
+
+            foreach (self::DISCOVERY_MAP as $discoveryKey => $property) {
+                if ($this->{$property} === '' && !empty($document[$discoveryKey])) {
+                    $this->{$property} = $document[$discoveryKey];
+                }
+            }
+        } catch (\Throwable) {
+            // Discovery failure is non-fatal; manually configured endpoints
+            // (if any) remain untouched.
+        }
+    }
+
+    /**
+     * Fetch and parse an OIDC discovery document.
+     *
+     * @return array<string, mixed>
+     * @throws \RuntimeException
+     */
+    private function fetchDiscoveryDocument(string $discoveryUrl): array
+    {
+        $discoveryUrl = $this->normalizeDiscoveryUrl($discoveryUrl);
+
+        $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
+        $response = $requestFactory->request(
+            $discoveryUrl,
+            'GET',
+            ['headers' => ['Accept' => 'application/json']]
+        );
+
+        $data = json_decode((string)$response->getBody(), true);
+
+        if (!is_array($data) || empty($data['authorization_endpoint'])) {
+            throw new \RuntimeException(
+                'Invalid OIDC Discovery response from ' . $discoveryUrl,
+                1744200001
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Normalize discovery URL:
+     * - Bare domain → prepend https://
+     * - Missing /.well-known/ path → append it
+     */
+    private function normalizeDiscoveryUrl(string $url): string
+    {
+        if (!str_starts_with($url, 'http')) {
+            $url = 'https://' . $url;
+        }
+
+        if (!str_contains($url, '.well-known')) {
+            $url = rtrim($url, '/') . '/.well-known/openid-configuration';
+        }
+
+        return $url;
     }
 
     protected function getExtensionConfiguration(): array

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -187,20 +187,34 @@ class OAuthService
         }
 
         $provider = $this->getProvider();
+
+        $headers = [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        // Only use Basic Auth for confidential clients (with clientSecret)
+        if ($this->settings->oidcClientSecret !== '') {
+            $headers['Authorization'] = 'Basic ' . base64_encode(
+                $this->settings->oidcClientKey . ':' . $this->settings->oidcClientSecret
+            );
+        }
+
+        $body = 'token=' . $token->getToken();
+        // Public clients must identify via client_id in body
+        if ($this->settings->oidcClientSecret === '') {
+            $body .= '&client_id=' . urlencode($this->settings->oidcClientKey);
+        }
+
         $request = $provider->getRequest(
             AbstractProvider::METHOD_POST,
             $this->settings->endpointRevoke,
             [
-                'headers' => [
-                    'Authorization' => 'Basic ' . base64_encode($this->settings->oidcClientKey . ':' . $this->settings->oidcClientSecret),
-                    'Content-Type' => 'application/x-www-form-urlencoded',
-                ],
-                'body' => 'token=' . $token->getToken(),
+                'headers' => $headers,
+                'body' => $body,
             ]
         );
 
         $response = $provider->getParsedResponse($request);
-        // TODO error handling?
 
         return true;
     }

--- a/Classes/Service/OpenIdConnectService.php
+++ b/Classes/Service/OpenIdConnectService.php
@@ -73,8 +73,9 @@ class OpenIdConnectService implements LoggerAwareInterface
      */
     public function generateAuthenticationContext(ServerRequestInterface $request, array $authorizationUrlOptions = []): AuthenticationContext
     {
+        $isPublicClient = $this->config->enableCodeVerifier && $this->config->oidcClientSecret === '';
         if (!$this->config->oidcClientKey
-            || !$this->config->oidcClientSecret
+            || (!$isPublicClient && !$this->config->oidcClientSecret)
             || !$this->config->endpointAuthorize
             || !$this->config->endpointToken
         ) {

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -62,6 +62,10 @@
 				<source>Disable CSRF attack mitigation: CAUTION! This is a security protection which checks the return state with the expected value. Disable this protection at your own risk.</source>
 				<target>Deaktivieren Sie die Abschwächung von CSRF-Angriffen: ACHTUNG! Dies ist ein Sicherheitsschutz, der den Rückgabewert mit dem erwarteten Wert abgleicht. Deaktivieren Sie diesen Schutz auf Ihr eigenes Risiko.</target>
 			</trans-unit>
+			<trans-unit id="settings.oidcDiscoveryUrl">
+				<source>OIDC Discovery URL: Provider URL or full .well-known/openid-configuration URL. If set, empty endpoint fields are auto-filled from the discovery document.</source>
+				<target>OIDC Discovery URL: Provider-URL oder vollständige .well-known/openid-configuration URL. Wenn gesetzt, werden leere Endpunkt-Felder automatisch aus dem Discovery-Dokument befüllt.</target>
+			</trans-unit>
 			<trans-unit id="settings.oidcEndpointAuthorize">
 				<source>Endpoint URI for authorization</source>
 				<target>Endpunkt-URI für Autorisierung</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -50,6 +50,9 @@
 			<trans-unit id="settings.oidcDisableCSRFProtection">
 				<source>Disable CSRF attack mitigation: CAUTION! This is a security protection which checks the return state with the expected value. Disable this protection at your own risk.</source>
 			</trans-unit>
+			<trans-unit id="settings.oidcDiscoveryUrl">
+				<source>OIDC Discovery URL: Provider URL or full .well-known/openid-configuration URL. If set, empty endpoint fields are auto-filled from the discovery document.</source>
+			</trans-unit>
 			<trans-unit id="settings.oidcEndpointAuthorize">
 				<source>Endpoint URI for authorization</source>
 			</trans-unit>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -37,6 +37,9 @@ oidcClientScopes = openid
 # cat=basic//6; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcClientScopeSeparator
 oidcClientScopeSeparator =
 
+# cat=advanced/links/0; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcDiscoveryUrl
+oidcDiscoveryUrl =
+
 # cat=advanced/links/1; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcEndpointAuthorize
 oidcEndpointAuthorize =
 


### PR DESCRIPTION
## Summary

This PR adds two opt-in features to the `causal/oidc` extension (targeting
`master`), both fully backward-compatible with existing installations:

1. **OIDC Discovery Endpoint** — automatically resolves endpoint URLs from a
   provider's `.well-known/openid-configuration` document
2. **PKCE Public Client** — allows authentication without a `clientSecret`
   (e.g. Zitadel with Auth Method = NONE)

**7 files changed, 141 insertions(+), 8 deletions(-)**

---

## Feature 1: OIDC Discovery Endpoint

Discovery support is integrated directly into the `OidcConfiguration` DTO —
no additional services or classes required.

**How it works:**

- A new property `oidcDiscoveryUrl` is added to `OidcConfiguration`
- During construction, if `oidcDiscoveryUrl` is set and any endpoint URL is
  empty, `applyDiscovery()` fetches the provider's OpenID Configuration
  document and fills in the missing endpoints automatically
- Manually configured endpoints always take precedence over discovered values
- If `oidcDiscoveryUrl` is empty (the default), `applyDiscovery()` returns
  immediately — **no HTTP overhead for existing installations**
- Discovery failure is non-fatal (wrapped in `try/catch`) — manually
  configured endpoints remain untouched

**Configuration:**

```
# Extension Manager → Advanced → oidcDiscoveryUrl
oidcDiscoveryUrl = https://identity.example.com
# Or full URL:
oidcDiscoveryUrl = https://identity.example.com/.well-known/openid-configuration
```

Bare domain input is automatically normalized to
`https://` + `/.well-known/openid-configuration`.

**Resolved endpoints from discovery:**

| Discovery document key   | OidcConfiguration property |
|--------------------------|---------------------------|
| `authorization_endpoint` | `endpointAuthorize`       |
| `token_endpoint`         | `endpointToken`           |
| `userinfo_endpoint`      | `endpointUserInfo`        |
| `end_session_endpoint`   | `endpointLogout`          |
| `revocation_endpoint`    | `endpointRevoke`          |

---

## Feature 2: PKCE Public Client (no `clientSecret`)

Enables use with OAuth2 providers configured as **public clients**
(Auth Method = NONE), such as Zitadel.

Previously, `generateAuthenticationContext()` would throw
`InvalidArgumentException: Missing extension configuration` when `clientSecret`
was empty, even if PKCE was active. This PR relaxes that validation for public
clients.

**How it works:**

A client is treated as a "public client" when **both** conditions are met:

- `enableCodeVerifier = 1` (PKCE enabled)
- `oidcClientSecret` is empty

In this case:
- The `clientSecret` validation is skipped in `OpenIdConnectService`
- An empty string is passed to `GenericOpenIdProvider` via the factory
- Token revocation uses `client_id` in the POST body instead of Basic Auth
  (per [RFC 7009 Section 2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1))

Confidential clients (with `clientSecret`) are completely unaffected.

---

## Changes

### Modified: `Classes/OidcConfiguration.php` (+101 lines)

- New property: `public string $oidcDiscoveryUrl = ''`
- New constant: `DISCOVERY_MAP` — maps discovery keys to DTO properties
- New method: `applyDiscovery()` — fetches and applies discovery document
- New method: `fetchDiscoveryDocument()` — HTTP GET + JSON parse with validation
- New method: `normalizeDiscoveryUrl()` — prepends `https://` and appends
  `/.well-known/openid-configuration` if missing
- `applyDiscovery()` is called at the end of `__construct()` after all
  explicit config values are set

### Modified: `Classes/Service/OpenIdConnectService.php` (+2/-1)

- `generateAuthenticationContext()`: introduces `$isPublicClient` check —
  skips `oidcClientSecret` validation when PKCE is enabled and no secret
  is configured

### Modified: `Classes/Factory/GenericOAuthProviderFactory.php` (+7/-1)

- PKCE public client path: explicitly handles empty `clientSecret` when
  `enableCodeVerifier = true` and no secret is configured

### Modified: `Classes/Service/OAuthService.php` (+22/-6)

- `revokeToken()`: refactored to handle both client types:
  - **Confidential clients**: Basic Auth header (existing behavior)
  - **Public clients**: `client_id` in POST body, no Basic Auth
    (per RFC 7009 Section 2.1)
- Removed `// TODO error handling?` comment

### Configuration / Resources

- `ext_conf_template.txt`: new `oidcDiscoveryUrl` field (empty by default,
  category `advanced/links/0`)
- `locallang_db.xlf`: EN label for `settings.oidcDiscoveryUrl`
- `de.locallang_db.xlf`: DE translation for `settings.oidcDiscoveryUrl`

---

## Backward Compatibility

| Scenario | Impact |
|---|---|
| Existing installation, no `oidcDiscoveryUrl` set | ✅ None — `applyDiscovery()` returns immediately |
| Existing installation, `enableCodeVerifier = 0` | ✅ None — PKCE public client path never activated |
| Existing installation, `clientSecret` configured | ✅ None — confidential client flow unchanged |
| Token revocation with `clientSecret` | ✅ None — Basic Auth still used for confidential clients |
| Discovery endpoint unreachable | ✅ Non-fatal — `try/catch` preserves manual config |

No database migrations required. No breaking changes to existing configuration.
The new `oidcDiscoveryUrl` setting defaults to empty string.

---

## Testing

- Tested against **Zitadel** (OIDC Discovery + PKCE Public Client,
  Auth Method = NONE) on TYPO3 13.4
- Verified Discovery auto-fills all 5 endpoint properties from
  `.well-known/openid-configuration`
- Verified PKCE flow with empty `clientSecret` completes successfully
- Verified existing provider setup (manual endpoints, confidential client)
  remains completely unaffected
