### PR TITLE
[FEATURE] #141 Add backend oidc authentication

### DIFF
--- a/Classes/LoginProvider/OidcLoginProvider.php
+++ b/Classes/LoginProvider/OidcLoginProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Causal\Oidc\LoginProvider;
+
+use TYPO3\CMS\Backend\Controller\LoginController;
+use TYPO3\CMS\Backend\LoginProvider\LoginProviderInterface;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+
+class OidcLoginProvider implements LoginProviderInterface
+{
+    /**
+     * @var int
+     */
+    public const IDENTIFIER = 1742888452490;
+
+    /**
+     * @inheritDoc
+     */
+    public function render(StandaloneView $view, PageRenderer $pageRenderer, LoginController $loginController)
+    {
+        $view->setTemplatePathAndFilename(
+            GeneralUtility::getFileAbsFileName('EXT:oidc/Resources/Private/Templates/Backend/LoginOidc.html')
+        );
+
+        $view->assign('enablePasswordReset', false);
+    }
+}

--- a/Classes/OidcConfiguration.php
+++ b/Classes/OidcConfiguration.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class OidcConfiguration
 {
+    public bool $enableBackendAuthentication = false;
     public bool $enableFrontendAuthentication = false;
     public int $authenticationServicePriority = 82;
     public int $authenticationServiceQuality = 80;
@@ -44,6 +45,7 @@ final class OidcConfiguration
     {
         $extConfig = $extConfig ?: $this->getExtensionConfiguration();
 
+        $this->enableBackendAuthentication = (bool)$extConfig['enableBackendAuthentication'];
         $this->enableFrontendAuthentication = (bool)$extConfig['enableFrontendAuthentication'];
         $this->authenticationServicePriority = (int)$extConfig['authenticationServicePriority'];
         $this->authenticationServiceQuality = (int)$extConfig['authenticationServiceQuality'];

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -385,7 +385,7 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
         }
 
         $newUserGroups = [];
-        $defaultUserGroups = GeneralUtility::intExplode(',', $this->config->usersDefaultGroup);
+        $defaultUserGroups = GeneralUtility::intExplode(',', $this->config->usersDefaultGroup, true);
 
         if (!empty($row['usergroup'])) {
             $currentUserGroups = GeneralUtility::intExplode(',', $row['usergroup'], true);

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -21,4 +21,15 @@ return [
             ],
         ],
     ],
+    'backend' => [
+        'oidccallback' => [
+            'target' => \Causal\Oidc\Middleware\OauthCallback::class,
+            'after' => [
+                'typo3/cms-core/request-token-middleware',
+            ],
+            'before' => [
+                'typo3/cms-backend/authentication',
+            ],
+        ],
+    ],
 ];

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -17,6 +17,9 @@
 			<trans-unit id="settings.authenticationUrlRoute">
 				<source>Route for retrieving the authentication URL of the Identity Provider</source>
 			</trans-unit>
+			<trans-unit id="settings.enableBackendAuthentication">
+				<source>Backend Authentication: Enable OpenID Connect authentication for the backend.</source>
+			</trans-unit>
 			<trans-unit id="settings.enableCodeVerifier">
 				<source>Enable PKCE: Enable PKCE flow. Code challenge and code verifier will be sent along.</source>
 			</trans-unit>

--- a/Resources/Private/Templates/Backend/LoginOidc.html
+++ b/Resources/Private/Templates/Backend/LoginOidc.html
@@ -1,0 +1,24 @@
+<f:layout name="Login" />
+
+<f:section name="loginFormFields">
+    <div class="form-group t3js-login-username-section" id="t3-login-username-section">
+        <f:if condition="{loginError}">
+            <div class="t3js-login-error" id="t3-login-error">
+                <div class="alert alert-danger">
+                    <strong><f:translate key="login.error.headline" extensionName="oidc" /></strong>
+                    <p><f:translate key="login.error.message" extensionName="oidc" /></p>
+                </div>
+            </div>
+        </f:if>
+
+        OIDC Login
+        <input type="hidden" id="login-provider" name="login-provider" value="oidc"/>
+    </div>
+</f:section>
+<f:section name="ResetPassword">
+    <div class="forgot-password">
+        <div class="text-right">
+            <f:be.link route="password_forget" parameters="{loginProvider: loginProviderIdentifier}">{f:translate(key: 'login.password_forget')}</f:be.link>
+        </div>
+    </div>
+</f:section>

--- a/Tests/Unit/AbstractUnitTestBase.php
+++ b/Tests/Unit/AbstractUnitTestBase.php
@@ -22,6 +22,7 @@ class AbstractUnitTestBase extends UnitTestCase
     protected function setupOidcConfiguration(): OidcConfiguration
     {
         return new OidcConfiguration([
+            'enableBackendAuthentication' => 0,
             'enableFrontendAuthentication' => 0,
             'reEnableFrontendUsers' => 0,
             'undeleteFrontendUsers' => 0,

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,3 +1,6 @@
+# cat=basic/enable/1; type=boolean; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.enableBackendAuthentication
+enableBackendAuthentication = 0
+
 # cat=basic/enable/1; type=boolean; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.enableFrontendAuthentication
 enableFrontendAuthentication = 0
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -5,7 +5,19 @@ CREATE TABLE fe_users
 	KEY fk_oidc (tx_oidc)
 );
 
+CREATE TABLE be_users
+(
+	tx_oidc varchar(100) DEFAULT '' NOT NULL,
+
+	KEY fk_oidc (tx_oidc)
+);
+
 CREATE TABLE fe_groups
+(
+	tx_oidc_pattern varchar(255) DEFAULT '' NOT NULL
+);
+
+CREATE TABLE be_groups
 (
 	tx_oidc_pattern varchar(255) DEFAULT '' NOT NULL
 );


### PR DESCRIPTION
Allow users to login to the backend with oidc authentication.
* Add the *BE subtypes to the authentication service
* Extend the authentication service to handle backend logins
* Allow backend login without a working web frontend