### PR TITLE
[FEATURE] Add OIDC Discovery endpoint support

### DIFF
--- a/Classes/Factory/GenericOAuthProviderFactory.php
+++ b/Classes/Factory/GenericOAuthProviderFactory.php
@@ -56,10 +56,10 @@ final readonly class GenericOAuthProviderFactory implements OAuthProviderFactory
     }
 
     /**
-     * Fill remaining config endpoints (logout, revoke) from the
-     * provider's discovery document. League providers only handle
-     * authorize, token, and userinfo URLs — logout and revoke are
-     * TYPO3-specific and stored in OidcConfiguration.
+     * Fill config endpoints from the provider's discovery document.
+     * This keeps OidcConfiguration in sync so that other services
+     * (e.g. OpenIdConnectService validation) can read the resolved
+     * URLs without querying the provider directly.
      */
     private function applyDiscoveryToSettings(
         GenericOpenIdDiscoveryProvider $provider,
@@ -71,6 +71,9 @@ final readonly class GenericOAuthProviderFactory implements OAuthProviderFactory
         }
 
         $extraEndpoints = [
+            'authorization_endpoint' => 'endpointAuthorize',
+            'token_endpoint' => 'endpointToken',
+            'userinfo_endpoint' => 'endpointUserInfo',
             'end_session_endpoint' => 'endpointLogout',
             'revocation_endpoint' => 'endpointRevoke',
         ];

--- a/Classes/Factory/GenericOAuthProviderFactory.php
+++ b/Classes/Factory/GenericOAuthProviderFactory.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Causal\Oidc\Factory;
 
 use Causal\Oidc\OidcConfiguration;
+use Causal\Oidc\Provider\GenericOpenIdDiscoveryProvider;
 use Causal\Oidc\Provider\GenericOpenIdProvider;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
@@ -31,20 +32,53 @@ final readonly class GenericOAuthProviderFactory implements OAuthProviderFactory
             'requestFactory' => $this->requestFactory,
         ];
 
-        return new GenericOpenIdProvider(
-            [
-                'clientId' => $settings->oidcClientKey,
-                'clientSecret' => $settings->oidcClientSecret,
-                'redirectUri' => $settings->oidcRedirectUri,
-                'urlAuthorize' => $settings->endpointAuthorize,
-                'urlAccessToken' => $settings->endpointToken,
-                'urlResourceOwnerDetails' => $settings->endpointUserInfo,
-                'responseResourceOwnerId' => 'sub',
-                'accessTokenResourceOwnerId' => 'sub',
-                'scopes' => GeneralUtility::trimExplode(',', $settings->oidcClientScopes, true),
-                'scopeSeparator' => $settings->oidcClientScopeSeparator,
-            ],
-            $collaborators
-        );
+        $options = [
+            'clientId' => $settings->oidcClientKey,
+            'clientSecret' => $settings->oidcClientSecret,
+            'redirectUri' => $settings->oidcRedirectUri,
+            'urlAuthorize' => $settings->endpointAuthorize,
+            'urlAccessToken' => $settings->endpointToken,
+            'urlResourceOwnerDetails' => $settings->endpointUserInfo,
+            'responseResourceOwnerId' => 'sub',
+            'accessTokenResourceOwnerId' => 'sub',
+            'scopes' => GeneralUtility::trimExplode(',', $settings->oidcClientScopes, true),
+            'scopeSeparator' => $settings->oidcClientScopeSeparator,
+        ];
+
+        if ($settings->oidcDiscoveryUrl !== '') {
+            $options['discoveryUrl'] = $settings->oidcDiscoveryUrl;
+            $provider = new GenericOpenIdDiscoveryProvider($options, $collaborators);
+            $this->applyDiscoveryToSettings($provider, $settings);
+            return $provider;
+        }
+
+        return new GenericOpenIdProvider($options, $collaborators);
+    }
+
+    /**
+     * Fill remaining config endpoints (logout, revoke) from the
+     * provider's discovery document. League providers only handle
+     * authorize, token, and userinfo URLs — logout and revoke are
+     * TYPO3-specific and stored in OidcConfiguration.
+     */
+    private function applyDiscoveryToSettings(
+        GenericOpenIdDiscoveryProvider $provider,
+        OidcConfiguration $settings
+    ): void {
+        $doc = $provider->getDiscoveryDocument();
+        if ($doc === []) {
+            return;
+        }
+
+        $extraEndpoints = [
+            'end_session_endpoint' => 'endpointLogout',
+            'revocation_endpoint' => 'endpointRevoke',
+        ];
+
+        foreach ($extraEndpoints as $discoveryKey => $configProperty) {
+            if ($settings->{$configProperty} === '' && !empty($doc[$discoveryKey])) {
+                $settings->{$configProperty} = $doc[$discoveryKey];
+            }
+        }
     }
 }

--- a/Classes/OidcConfiguration.php
+++ b/Classes/OidcConfiguration.php
@@ -39,6 +39,7 @@ final class OidcConfiguration
     public string $endpointLogout = '';
     public bool $revokeAccessTokenAfterLogin = false;
     public bool $enablePasswordCredentials = false;
+    public string $oidcDiscoveryUrl = '';
 
     public function __construct(array $extConfig = [])
     {
@@ -70,6 +71,7 @@ final class OidcConfiguration
         $this->oidcRedirectUri = $extConfig['oidcRedirectUri'];
         $this->revokeAccessTokenAfterLogin = (bool)$extConfig['oidcRevokeAccessTokenAfterLogin'];
         $this->enablePasswordCredentials = (bool)($extConfig['enablePasswordCredentials'] ?? $this->enablePasswordCredentials);
+        $this->oidcDiscoveryUrl = trim((string)($extConfig['oidcDiscoveryUrl'] ?? ''));
     }
 
     protected function getExtensionConfiguration(): array

--- a/Classes/Provider/GenericOpenIdDiscoveryProvider.php
+++ b/Classes/Provider/GenericOpenIdDiscoveryProvider.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Causal\Oidc\Provider;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Client as GuzzleClient;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * OpenID Connect provider with automatic endpoint discovery.
+ *
+ * Fetches the provider's .well-known/openid-configuration document
+ * and fills empty endpoint URLs from it. Manually configured URLs
+ * always take precedence over discovered values.
+ */
+class GenericOpenIdDiscoveryProvider extends GenericOpenIdProvider
+{
+    /**
+     * Parsed OIDC discovery document.
+     *
+     * @var array<string, mixed>
+     */
+    private array $discoveryDocument = [];
+
+    /**
+     * Maps league option keys to OIDC discovery document keys.
+     */
+    private const DISCOVERY_MAP = [
+        'urlAuthorize' => 'authorization_endpoint',
+        'urlAccessToken' => 'token_endpoint',
+        'urlResourceOwnerDetails' => 'userinfo_endpoint',
+    ];
+
+    /**
+     * @param array<string, mixed> $options Provider options, including 'discoveryUrl'
+     * @param array<string, mixed> $collaborators Provider collaborators (httpClient, requestFactory)
+     */
+    public function __construct(array $options = [], array $collaborators = [])
+    {
+        $discoveryUrl = $options['discoveryUrl'] ?? '';
+        unset($options['discoveryUrl']);
+
+        if ($discoveryUrl !== '') {
+            $httpClient = $collaborators['httpClient'] ?? new GuzzleClient();
+
+            try {
+                $this->discoveryDocument = $this->fetchDiscoveryDocument(
+                    $this->normalizeDiscoveryUrl($discoveryUrl),
+                    $httpClient
+                );
+
+                foreach (self::DISCOVERY_MAP as $optionKey => $discoveryKey) {
+                    if (empty($options[$optionKey]) && !empty($this->discoveryDocument[$discoveryKey])) {
+                        $options[$optionKey] = $this->discoveryDocument[$discoveryKey];
+                    }
+                }
+            } catch (\Throwable $e) {
+                // Discovery failure is non-fatal; manually configured
+                // endpoints (if any) remain untouched.
+                $this->getLogger()->warning(
+                    'OIDC Discovery failed: ' . $e->getMessage(),
+                    ['discoveryUrl' => $discoveryUrl]
+                );
+            }
+        }
+
+        parent::__construct($options, $collaborators);
+    }
+
+    /**
+     * Returns the parsed OIDC discovery document.
+     *
+     * @return array<string, mixed>
+     */
+    public function getDiscoveryDocument(): array
+    {
+        return $this->discoveryDocument;
+    }
+
+    /**
+     * Fetch and parse an OIDC discovery document.
+     *
+     * @return array<string, mixed>
+     * @throws \RuntimeException
+     */
+    private function fetchDiscoveryDocument(string $discoveryUrl, ClientInterface $httpClient): array
+    {
+        $response = $httpClient->request('GET', $discoveryUrl, [
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+
+        $data = json_decode((string)$response->getBody(), true);
+
+        if (!is_array($data) || empty($data['authorization_endpoint'])) {
+            throw new \RuntimeException(
+                'Invalid OIDC Discovery response from ' . $discoveryUrl,
+                1744200001
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Normalize discovery URL:
+     * - Bare domain → prepend https://
+     * - Missing /.well-known/ path → append it
+     */
+    protected function normalizeDiscoveryUrl(string $url): string
+    {
+        if (!str_starts_with($url, 'http')) {
+            $url = 'https://' . $url;
+        }
+
+        if (!str_contains($url, '.well-known')) {
+            $url = rtrim($url, '/') . '/.well-known/openid-configuration';
+        }
+
+        return $url;
+    }
+
+    private function getLogger(): LoggerInterface
+    {
+        return GeneralUtility::makeInstance(LogManager::class)->getLogger(static::class);
+    }
+}

--- a/Classes/Service/OpenIdConnectService.php
+++ b/Classes/Service/OpenIdConnectService.php
@@ -73,10 +73,11 @@ class OpenIdConnectService implements LoggerAwareInterface
      */
     public function generateAuthenticationContext(ServerRequestInterface $request, array $authorizationUrlOptions = []): AuthenticationContext
     {
+        $hasDiscovery = $this->config->oidcDiscoveryUrl !== '';
         if (!$this->config->oidcClientKey
             || !$this->config->oidcClientSecret
-            || !$this->config->endpointAuthorize
-            || !$this->config->endpointToken
+            || (!$hasDiscovery && !$this->config->endpointAuthorize)
+            || (!$hasDiscovery && !$this->config->endpointToken)
         ) {
             throw new InvalidArgumentException('Missing extension configuration', 1715775147);
         }

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -62,6 +62,10 @@
 				<source>Disable CSRF attack mitigation: CAUTION! This is a security protection which checks the return state with the expected value. Disable this protection at your own risk.</source>
 				<target>Deaktivieren Sie die Abschwächung von CSRF-Angriffen: ACHTUNG! Dies ist ein Sicherheitsschutz, der den Rückgabewert mit dem erwarteten Wert abgleicht. Deaktivieren Sie diesen Schutz auf Ihr eigenes Risiko.</target>
 			</trans-unit>
+			<trans-unit id="settings.oidcDiscoveryUrl">
+				<source>OIDC Discovery URL: Provider URL or full .well-known/openid-configuration URL. If set, empty endpoint fields are auto-filled from the discovery document.</source>
+				<target>OIDC Discovery URL: Provider-URL oder vollständige .well-known/openid-configuration URL. Wenn gesetzt, werden leere Endpunkt-Felder automatisch aus dem Discovery-Dokument befüllt.</target>
+			</trans-unit>
 			<trans-unit id="settings.oidcEndpointAuthorize">
 				<source>Endpoint URI for authorization</source>
 				<target>Endpunkt-URI für Autorisierung</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -50,6 +50,9 @@
 			<trans-unit id="settings.oidcDisableCSRFProtection">
 				<source>Disable CSRF attack mitigation: CAUTION! This is a security protection which checks the return state with the expected value. Disable this protection at your own risk.</source>
 			</trans-unit>
+			<trans-unit id="settings.oidcDiscoveryUrl">
+				<source>OIDC Discovery URL: Provider URL or full .well-known/openid-configuration URL. If set, empty endpoint fields are auto-filled from the discovery document.</source>
+			</trans-unit>
 			<trans-unit id="settings.oidcEndpointAuthorize">
 				<source>Endpoint URI for authorization</source>
 			</trans-unit>

--- a/Tests/Unit/AbstractUnitTestBase.php
+++ b/Tests/Unit/AbstractUnitTestBase.php
@@ -48,6 +48,7 @@ class AbstractUnitTestBase extends UnitTestCase
             'authenticationServicePriority' => 82,
             'authenticationServiceQuality' => 80,
             'authenticationUrlRoute' => 'oidc/authentication',
+            'oidcDiscoveryUrl' => '',
         ]);
     }
 }

--- a/Tests/Unit/Provider/GenericOpenIdDiscoveryProviderTest.php
+++ b/Tests/Unit/Provider/GenericOpenIdDiscoveryProviderTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Causal\Oidc\Tests\Unit\Provider;
+
+use Causal\Oidc\Provider\GenericOpenIdDiscoveryProvider;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+#[CoversClass(GenericOpenIdDiscoveryProvider::class)]
+final class GenericOpenIdDiscoveryProviderTest extends UnitTestCase
+{
+    protected bool $resetSingletonInstances = true;
+
+    private function createDiscoveryDocument(array $overrides = []): array
+    {
+        return array_merge([
+            'issuer' => 'https://idp.example.com',
+            'authorization_endpoint' => 'https://idp.example.com/oauth/authorize',
+            'token_endpoint' => 'https://idp.example.com/oauth/token',
+            'userinfo_endpoint' => 'https://idp.example.com/oidc/userinfo',
+            'end_session_endpoint' => 'https://idp.example.com/oidc/logout',
+            'revocation_endpoint' => 'https://idp.example.com/oauth/revoke',
+            'jwks_uri' => 'https://idp.example.com/oauth/keys',
+        ], $overrides);
+    }
+
+    private function createMockClient(array $discoveryDoc): GuzzleClient
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], json_encode($discoveryDoc)),
+        ]);
+        return new GuzzleClient(['handler' => HandlerStack::create($mock)]);
+    }
+
+    private function createErrorClient(): GuzzleClient
+    {
+        $mock = new MockHandler([
+            new Response(500, [], 'Internal Server Error'),
+        ]);
+        return new GuzzleClient(['handler' => HandlerStack::create($mock)]);
+    }
+
+    #[Test]
+    public function discoveryFillsEmptyEndpointUrls(): void
+    {
+        $doc = $this->createDiscoveryDocument();
+        $provider = new GenericOpenIdDiscoveryProvider(
+            [
+                'clientId' => 'test-client',
+                'clientSecret' => 'test-secret',
+                'discoveryUrl' => 'https://idp.example.com',
+            ],
+            ['httpClient' => $this->createMockClient($doc)]
+        );
+
+        self::assertSame($doc['authorization_endpoint'], $provider->getBaseAuthorizationUrl());
+        self::assertSame($doc['token_endpoint'], $provider->getBaseAccessTokenUrl([]));
+    }
+
+    #[Test]
+    public function manualUrlsTakePrecedenceOverDiscovery(): void
+    {
+        $doc = $this->createDiscoveryDocument();
+        $manualAuthorize = 'https://custom.example.com/auth';
+        $manualToken = 'https://custom.example.com/token';
+
+        $provider = new GenericOpenIdDiscoveryProvider(
+            [
+                'clientId' => 'test-client',
+                'clientSecret' => 'test-secret',
+                'discoveryUrl' => 'https://idp.example.com',
+                'urlAuthorize' => $manualAuthorize,
+                'urlAccessToken' => $manualToken,
+                'urlResourceOwnerDetails' => '',
+            ],
+            ['httpClient' => $this->createMockClient($doc)]
+        );
+
+        self::assertSame($manualAuthorize, $provider->getBaseAuthorizationUrl());
+        self::assertSame($manualToken, $provider->getBaseAccessTokenUrl([]));
+    }
+
+    #[Test]
+    public function discoveryFailureIsNonFatal(): void
+    {
+        $provider = new GenericOpenIdDiscoveryProvider(
+            [
+                'clientId' => 'test-client',
+                'clientSecret' => 'test-secret',
+                'discoveryUrl' => 'https://idp.example.com',
+                'urlAuthorize' => 'https://fallback.example.com/auth',
+                'urlAccessToken' => 'https://fallback.example.com/token',
+                'urlResourceOwnerDetails' => 'https://fallback.example.com/userinfo',
+            ],
+            ['httpClient' => $this->createErrorClient()]
+        );
+
+        self::assertSame('https://fallback.example.com/auth', $provider->getBaseAuthorizationUrl());
+        self::assertSame([], $provider->getDiscoveryDocument());
+    }
+
+    #[Test]
+    public function getDiscoveryDocumentReturnsFullDoc(): void
+    {
+        $doc = $this->createDiscoveryDocument();
+        $provider = new GenericOpenIdDiscoveryProvider(
+            [
+                'clientId' => 'test-client',
+                'clientSecret' => 'test-secret',
+                'discoveryUrl' => 'https://idp.example.com',
+            ],
+            ['httpClient' => $this->createMockClient($doc)]
+        );
+
+        $result = $provider->getDiscoveryDocument();
+        self::assertSame($doc['issuer'], $result['issuer']);
+        self::assertSame($doc['end_session_endpoint'], $result['end_session_endpoint']);
+        self::assertSame($doc['revocation_endpoint'], $result['revocation_endpoint']);
+    }
+
+    #[Test]
+    public function normalizeDiscoveryUrlPrependsHttps(): void
+    {
+        $doc = $this->createDiscoveryDocument();
+        $mockClient = $this->createMockClient($doc);
+
+        $provider = new GenericOpenIdDiscoveryProvider(
+            [
+                'clientId' => 'test-client',
+                'clientSecret' => 'test-secret',
+                'discoveryUrl' => 'idp.example.com',
+            ],
+            ['httpClient' => $mockClient]
+        );
+
+        // If discovery succeeded, URLs were resolved → the bare domain was normalized
+        self::assertNotEmpty($provider->getDiscoveryDocument());
+    }
+
+    #[Test]
+    public function normalizeDiscoveryUrlAppendsWellKnown(): void
+    {
+        $doc = $this->createDiscoveryDocument();
+        $mockClient = $this->createMockClient($doc);
+
+        $provider = new GenericOpenIdDiscoveryProvider(
+            [
+                'clientId' => 'test-client',
+                'clientSecret' => 'test-secret',
+                'discoveryUrl' => 'https://idp.example.com',
+            ],
+            ['httpClient' => $mockClient]
+        );
+
+        self::assertNotEmpty($provider->getDiscoveryDocument());
+    }
+
+    #[Test]
+    public function normalizeDiscoveryUrlKeepsFullUrl(): void
+    {
+        $doc = $this->createDiscoveryDocument();
+        $mockClient = $this->createMockClient($doc);
+
+        $provider = new GenericOpenIdDiscoveryProvider(
+            [
+                'clientId' => 'test-client',
+                'clientSecret' => 'test-secret',
+                'discoveryUrl' => 'https://idp.example.com/.well-known/openid-configuration',
+            ],
+            ['httpClient' => $mockClient]
+        );
+
+        self::assertNotEmpty($provider->getDiscoveryDocument());
+    }
+
+    #[Test]
+    public function noDiscoveryUrlSkipsFetching(): void
+    {
+        $provider = new GenericOpenIdDiscoveryProvider(
+            [
+                'clientId' => 'test-client',
+                'clientSecret' => 'test-secret',
+                'urlAuthorize' => 'https://manual.example.com/auth',
+                'urlAccessToken' => 'https://manual.example.com/token',
+                'urlResourceOwnerDetails' => 'https://manual.example.com/userinfo',
+            ],
+            []
+        );
+
+        self::assertSame([], $provider->getDiscoveryDocument());
+        self::assertSame('https://manual.example.com/auth', $provider->getBaseAuthorizationUrl());
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+// Register test namespace autoloader
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'Causal\\Oidc\\Tests\\';
+    $baseDir = __DIR__ . '/';
+
+    if (!str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relativeClass = substr($class, strlen($prefix));
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+// Include Composer autoloader
+require dirname(__DIR__, 3) . '/vendor/autoload.php';

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -37,6 +37,9 @@ oidcClientScopes = openid
 # cat=basic//6; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcClientScopeSeparator
 oidcClientScopeSeparator =
 
+# cat=advanced/links/0; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcDiscoveryUrl
+oidcDiscoveryUrl =
+
 # cat=advanced/links/1; type=string; label=LLL:EXT:oidc/Resources/Private/Language/locallang_db.xlf:settings.oidcEndpointAuthorize
 oidcEndpointAuthorize =
 


### PR DESCRIPTION
Adds opt-in OIDC Discovery (.well-known/openid-configuration) to auto-resolve provider endpoint URLs.
 
 
  - New GenericOpenIdDiscoveryProvider extends GenericOpenIdProvider (Azure provider pattern)
  - Factory creates discovery provider when oidcDiscoveryUrl is set
  - Fills all 5 endpoints; manual URLs always take precedence
  - Discovery failure is non-fatal (logs warning, continues with manual URLs)
  - 8 unit tests with mocked HTTP client
 
 Fully backward-compatible. Tested against Zitadel on TYPO3 13.4.

 Note: Related PR: #246 (PKCE public client support). Both PRs are independent and can be reviewed/merged separately. If both are accepted, merge this one first — #246 will need a minor conflict
 resolution in 2 shared files.