### PR TITLE
[FEATURE] Add PKCE public client support

### DIFF
--- a/Classes/Factory/GenericOAuthProviderFactory.php
+++ b/Classes/Factory/GenericOAuthProviderFactory.php
@@ -31,10 +31,17 @@ final readonly class GenericOAuthProviderFactory implements OAuthProviderFactory
             'requestFactory' => $this->requestFactory,
         ];
 
+        $clientSecret = $settings->oidcClientSecret;
+
+        // PKCE public client: no client secret required
+        if ($settings->enableCodeVerifier && $clientSecret === '') {
+            $clientSecret = '';
+        }
+
         return new GenericOpenIdProvider(
             [
                 'clientId' => $settings->oidcClientKey,
-                'clientSecret' => $settings->oidcClientSecret,
+                'clientSecret' => $clientSecret,
                 'redirectUri' => $settings->oidcRedirectUri,
                 'urlAuthorize' => $settings->endpointAuthorize,
                 'urlAccessToken' => $settings->endpointToken,

--- a/Classes/Service/OAuthService.php
+++ b/Classes/Service/OAuthService.php
@@ -187,20 +187,34 @@ class OAuthService
         }
 
         $provider = $this->getProvider();
+
+        $headers = [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ];
+
+        // Only use Basic Auth for confidential clients (with clientSecret)
+        if ($this->settings->oidcClientSecret !== '') {
+            $headers['Authorization'] = 'Basic ' . base64_encode(
+                $this->settings->oidcClientKey . ':' . $this->settings->oidcClientSecret
+            );
+        }
+
+        $body = 'token=' . $token->getToken();
+        // Public clients must identify via client_id in body (RFC 7009 §2.1)
+        if ($this->settings->oidcClientSecret === '') {
+            $body .= '&client_id=' . urlencode($this->settings->oidcClientKey);
+        }
+
         $request = $provider->getRequest(
             AbstractProvider::METHOD_POST,
             $this->settings->endpointRevoke,
             [
-                'headers' => [
-                    'Authorization' => 'Basic ' . base64_encode($this->settings->oidcClientKey . ':' . $this->settings->oidcClientSecret),
-                    'Content-Type' => 'application/x-www-form-urlencoded',
-                ],
-                'body' => 'token=' . $token->getToken(),
+                'headers' => $headers,
+                'body' => $body,
             ]
         );
 
-        $response = $provider->getParsedResponse($request);
-        // TODO error handling?
+        $provider->getParsedResponse($request);
 
         return true;
     }

--- a/Classes/Service/OpenIdConnectService.php
+++ b/Classes/Service/OpenIdConnectService.php
@@ -73,8 +73,9 @@ class OpenIdConnectService implements LoggerAwareInterface
      */
     public function generateAuthenticationContext(ServerRequestInterface $request, array $authorizationUrlOptions = []): AuthenticationContext
     {
+        $isPublicClient = $this->config->enableCodeVerifier && $this->config->oidcClientSecret === '';
         if (!$this->config->oidcClientKey
-            || !$this->config->oidcClientSecret
+            || (!$isPublicClient && !$this->config->oidcClientSecret)
             || !$this->config->endpointAuthorize
             || !$this->config->endpointToken
         ) {

--- a/Tests/Unit/Service/PkcePublicClientTest.php
+++ b/Tests/Unit/Service/PkcePublicClientTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Causal\Oidc\Tests\Unit\Service;
+
+use Causal\Oidc\OidcConfiguration;
+use Causal\Oidc\Service\AuthenticationContextService;
+use Causal\Oidc\Service\OAuthService;
+use Causal\Oidc\Service\OpenIdConnectService;
+use Causal\Oidc\Tests\Unit\AbstractUnitTestBase;
+use InvalidArgumentException;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Token\AccessToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionProperty;
+
+#[CoversClass(OpenIdConnectService::class)]
+#[CoversClass(OAuthService::class)]
+final class PkcePublicClientTest extends AbstractUnitTestBase
+{
+    protected bool $resetSingletonInstances = true;
+
+    private function createOidcConfig(array $overrides = []): OidcConfiguration
+    {
+        $defaults = [
+            'enableFrontendAuthentication' => 0,
+            'reEnableFrontendUsers' => 0,
+            'undeleteFrontendUsers' => 0,
+            'frontendUserMustExistLocally' => 0,
+            'enableCodeVerifier' => 0,
+            'enablePasswordCredentials' => 0,
+            'usersStoragePid' => 0,
+            'usersDefaultGroup' => '',
+            'oidcRedirectUri' => '',
+            'oidcClientKey' => 'test-client',
+            'oidcClientSecret' => 'test-secret',
+            'oidcClientScopes' => 'openid',
+            'oidcClientScopeSeparator' => '',
+            'oidcEndpointAuthorize' => 'https://idp.example.com/authorize',
+            'oidcEndpointToken' => 'https://idp.example.com/token',
+            'oidcEndpointUserInfo' => 'https://idp.example.com/userinfo',
+            'oidcEndpointLogout' => '',
+            'oidcEndpointRevoke' => 'https://idp.example.com/revoke',
+            'oidcAuthorizeLanguageParameter' => 'language',
+            'oidcUseRequestPathAuthentication' => 0,
+            'oidcRevokeAccessTokenAfterLogin' => 0,
+            'oidcDisableCSRFProtection' => 0,
+            'oauthProviderFactory' => '',
+            'authenticationServicePriority' => 82,
+            'authenticationServiceQuality' => 80,
+            'authenticationUrlRoute' => 'oidc/authentication',
+        ];
+
+        return new OidcConfiguration(array_merge($defaults, $overrides));
+    }
+
+    #[Test]
+    public function publicClientSkipsSecretValidation(): void
+    {
+        $config = $this->createOidcConfig([
+            'enableCodeVerifier' => 1,
+            'oidcClientSecret' => '',
+        ]);
+
+        $service = new OpenIdConnectService(
+            new OAuthService(self::createStub(EventDispatcherInterface::class), $config),
+            new AuthenticationContextService(),
+            $config,
+        );
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'login_url' => 'https://example.com/login',
+        ]);
+
+        // Should throw because of invalid login_url hash, NOT because of missing config.
+        // Code 1715775147 = missing config, code 1759845557572 = invalid login_url,
+        // code 1719003567 = invalid hash
+        try {
+            $service->generateAuthenticationContext($request);
+            self::fail('Expected InvalidArgumentException was not thrown');
+        } catch (InvalidArgumentException $e) {
+            self::assertNotSame(
+                1715775147,
+                $e->getCode(),
+                'Public client should not fail on missing clientSecret validation'
+            );
+        }
+    }
+
+    #[Test]
+    public function confidentialClientRequiresSecret(): void
+    {
+        $config = $this->createOidcConfig([
+            'enableCodeVerifier' => 0,
+            'oidcClientSecret' => '',
+        ]);
+
+        $service = new OpenIdConnectService(
+            new OAuthService(self::createStub(EventDispatcherInterface::class), $config),
+            new AuthenticationContextService(),
+            $config,
+        );
+
+        $request = $this->createMock(ServerRequestInterface::class);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1715775147);
+
+        $service->generateAuthenticationContext($request);
+    }
+
+    #[Test]
+    public function publicClientStillRequiresClientKey(): void
+    {
+        $config = $this->createOidcConfig([
+            'enableCodeVerifier' => 1,
+            'oidcClientKey' => '',
+            'oidcClientSecret' => '',
+        ]);
+
+        $service = new OpenIdConnectService(
+            new OAuthService(self::createStub(EventDispatcherInterface::class), $config),
+            new AuthenticationContextService(),
+            $config,
+        );
+
+        $request = $this->createMock(ServerRequestInterface::class);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1715775147);
+
+        $service->generateAuthenticationContext($request);
+    }
+
+    #[Test]
+    public function revokeTokenUsesBasicAuthForConfidentialClient(): void
+    {
+        $config = $this->createOidcConfig([
+            'oidcClientKey' => 'my-client',
+            'oidcClientSecret' => 'my-secret',
+        ]);
+
+        $oauthService = new OAuthService(
+            self::createStub(EventDispatcherInterface::class),
+            $config,
+        );
+
+        $provider = $this->createMock(AbstractProvider::class);
+        $provider->expects(self::once())
+            ->method('getRequest')
+            ->with(
+                'POST',
+                'https://idp.example.com/revoke',
+                self::callback(function (array $options) {
+                    // Confidential client: should have Authorization header
+                    self::assertArrayHasKey('Authorization', $options['headers']);
+                    self::assertStringStartsWith('Basic ', $options['headers']['Authorization']);
+                    // Body should NOT contain client_id
+                    self::assertStringNotContainsString('client_id', $options['body']);
+                    return true;
+                })
+            )
+            ->willReturn(self::createStub(RequestInterface::class));
+
+        $provider->method('getParsedResponse')->willReturn([]);
+
+        $this->setProviderOnService($oauthService, $provider);
+
+        $token = new AccessToken(['access_token' => 'test-token', 'expires' => time() + 3600]);
+        self::assertTrue($oauthService->revokeToken($token));
+    }
+
+    #[Test]
+    public function revokeTokenUsesClientIdInBodyForPublicClient(): void
+    {
+        $config = $this->createOidcConfig([
+            'oidcClientKey' => 'my-public-client',
+            'oidcClientSecret' => '',
+        ]);
+
+        $oauthService = new OAuthService(
+            self::createStub(EventDispatcherInterface::class),
+            $config,
+        );
+
+        $provider = $this->createMock(AbstractProvider::class);
+        $provider->expects(self::once())
+            ->method('getRequest')
+            ->with(
+                'POST',
+                'https://idp.example.com/revoke',
+                self::callback(function (array $options) {
+                    // Public client: should NOT have Authorization header
+                    self::assertArrayNotHasKey('Authorization', $options['headers']);
+                    // Body should contain client_id
+                    self::assertStringContainsString('client_id=my-public-client', $options['body']);
+                    return true;
+                })
+            )
+            ->willReturn(self::createStub(RequestInterface::class));
+
+        $provider->method('getParsedResponse')->willReturn([]);
+
+        $this->setProviderOnService($oauthService, $provider);
+
+        $token = new AccessToken(['access_token' => 'test-token', 'expires' => time() + 3600]);
+        self::assertTrue($oauthService->revokeToken($token));
+    }
+
+    private function setProviderOnService(OAuthService $service, AbstractProvider $provider): void
+    {
+        $reflection = new ReflectionProperty($service, 'provider');
+        $reflection->setValue($service, $provider);
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+// Register test namespace autoloader
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'Causal\\Oidc\\Tests\\';
+    $baseDir = __DIR__ . '/';
+
+    if (!str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relativeClass = substr($class, strlen($prefix));
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+// Include Composer autoloader
+require dirname(__DIR__, 3) . '/vendor/autoload.php';


### PR DESCRIPTION
Allows authentication without a client secret when PKCE is enabled (e.g., Zitadel with Auth Method = NONE).
 
 
  - Skip clientSecret validation for public clients
  - Token revocation: use client_id in body instead of Basic Auth (RFC 7009 §2.1)
  - 5 unit tests for validation and revocation
 
 Builds on existing PKCE code-verifier support in master. Fully backward-compatible.

Note: This PR shares 2 modified files with #245 (Discovery). If #245 is merged first, this PR will have minor merge conflicts in GenericOAuthProviderFactory.php and OpenIdConnectService.php. The
 resolution is straightforward — combine the $clientSecret/$isPublicClient logic from this PR with the $options array and $hasDiscovery check from #245. Happy to rebase once #245 is merged.